### PR TITLE
Add Import SSH Config feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,11 @@
             android:label="Port Forward Group"
             android:theme="@style/Theme.NectarSSH" />
         <activity
+            android:name="com.rosi.nectarssh.ImportSshConfigActivity"
+            android:exported="false"
+            android:label="Import SSH Config"
+            android:theme="@style/Theme.NectarSSH" />
+        <activity
             android:name="com.rosi.nectarssh.ui.connection.ConnectionLogActivity"
             android:exported="false"
             android:label="Connection Logs"

--- a/app/src/main/java/com/rosi/nectarssh/ConnectionManageActivity.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ConnectionManageActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.PlaylistAdd
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -132,6 +133,17 @@ fun ConnectionManageScreen(onBack: () -> Unit) {
         }
     }
 
+    val importSshConfigLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            portForwardsRefresh++
+            connectionsRefresh++
+            identitiesRefresh++
+            groupsRefresh++
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -149,6 +161,12 @@ fun ConnectionManageScreen(onBack: () -> Unit) {
                         }) {
                             Icon(Icons.Default.PlaylistAdd, contentDescription = "Batch Add")
                         }
+                    }
+                    IconButton(onClick = {
+                        val intent = Intent(context, ImportSshConfigActivity::class.java)
+                        importSshConfigLauncher.launch(intent)
+                    }) {
+                        Icon(Icons.Default.FileUpload, contentDescription = "Import SSH Config")
                     }
                 }
             )

--- a/app/src/main/java/com/rosi/nectarssh/ImportSshConfigActivity.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ImportSshConfigActivity.kt
@@ -1,0 +1,351 @@
+package com.rosi.nectarssh
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.rosi.nectarssh.data.Connection
+import com.rosi.nectarssh.data.ConnectionStorage
+import com.rosi.nectarssh.data.Identity
+import com.rosi.nectarssh.data.IdentityStorage
+import com.rosi.nectarssh.data.ParsedSshHost
+import com.rosi.nectarssh.data.PortForward
+import com.rosi.nectarssh.data.PortForwardStorage
+import com.rosi.nectarssh.data.SshConfigParser
+import com.rosi.nectarssh.ui.theme.NectarSSHTheme
+import java.util.UUID
+
+class ImportSshConfigActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val connectionStorage = ConnectionStorage(this)
+        val identityStorage = IdentityStorage(this)
+        val portForwardStorage = PortForwardStorage(this)
+
+        setContent {
+            NectarSSHTheme {
+                ImportSshConfigScreen(
+                    connectionStorage = connectionStorage,
+                    identityStorage = identityStorage,
+                    portForwardStorage = portForwardStorage,
+                    onDone = {
+                        setResult(Activity.RESULT_OK)
+                        finish()
+                    },
+                    onCancel = {
+                        setResult(Activity.RESULT_CANCELED)
+                        finish()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportSshConfigScreen(
+    connectionStorage: ConnectionStorage,
+    identityStorage: IdentityStorage,
+    portForwardStorage: PortForwardStorage,
+    onDone: () -> Unit,
+    onCancel: () -> Unit
+) {
+    var configText by remember { mutableStateOf("") }
+    var parsedHosts by remember { mutableStateOf<List<ParsedSshHost>>(emptyList()) }
+    var showPreview by remember { mutableStateOf(false) }
+    var importResult by remember { mutableStateOf<String?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Import SSH Config") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Cancel")
+                    }
+                },
+                actions = {
+                    if (showPreview && parsedHosts.isNotEmpty()) {
+                        IconButton(onClick = {
+                            val result = performImport(
+                                parsedHosts,
+                                connectionStorage,
+                                identityStorage,
+                                portForwardStorage
+                            )
+                            importResult = result
+                        }) {
+                            Icon(Icons.Default.Check, contentDescription = "Import")
+                        }
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+        ) {
+            if (importResult != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    )
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "Import Complete",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = importResult!!,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = onDone,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Done")
+                }
+            } else if (!showPreview) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Paste your SSH config below. Supports Host blocks with LocalForward directives, or standalone LocalForward lines.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = configText,
+                    onValueChange = { configText = it },
+                    label = { Text("SSH Config") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    minLines = 10
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = {
+                        parsedHosts = SshConfigParser.parse(configText)
+                        showPreview = true
+                    },
+                    enabled = configText.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Parse")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            } else {
+                if (parsedHosts.isEmpty()) {
+                    Spacer(modifier = Modifier.height(32.dp))
+                    Text(
+                        text = "No valid entries found. Check your input format.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.align(Alignment.CenterHorizontally)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    OutlinedButton(
+                        onClick = { showPreview = false },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Back to Edit")
+                    }
+                } else {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "Preview - ${parsedHosts.size} host(s) found",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    LazyColumn(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        items(parsedHosts) { host ->
+                            HostPreviewCard(host, connectionStorage, identityStorage)
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = { showPreview = false },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Back to Edit")
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun HostPreviewCard(
+    host: ParsedSshHost,
+    connectionStorage: ConnectionStorage,
+    identityStorage: IdentityStorage
+) {
+    val existingConnection = remember(host) {
+        connectionStorage.loadConnections().find {
+            it.address == host.hostname && it.port == host.port
+        }
+    }
+    val existingIdentity = remember(host) {
+        host.user?.let { user ->
+            identityStorage.loadIdentities().find { it.username == user }
+        }
+    }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = host.nickname,
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (host.hostname.isNotBlank()) {
+                Text(
+                    text = "${host.hostname}:${host.port}" +
+                            (host.user?.let { " (user: $it)" } ?: ""),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (existingConnection != null) {
+                Text(
+                    text = "Will use existing connection: ${existingConnection.nickname}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            } else if (host.hostname.isNotBlank()) {
+                Text(
+                    text = "Will create new connection" +
+                            if (existingIdentity != null) " using identity: ${existingIdentity.nickname}"
+                            else if (host.user != null) " and new identity for '${host.user}'"
+                            else " (no identity - configure later)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+
+            if (host.localForwards.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "${host.localForwards.size} port forward(s):",
+                    style = MaterialTheme.typography.labelMedium
+                )
+                host.localForwards.forEach { fwd ->
+                    Text(
+                        text = "  localhost:${fwd.localPort} -> ${fwd.remoteHost}:${fwd.remotePort}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun performImport(
+    hosts: List<ParsedSshHost>,
+    connectionStorage: ConnectionStorage,
+    identityStorage: IdentityStorage,
+    portForwardStorage: PortForwardStorage
+): String {
+    var connectionsCreated = 0
+    var identitiesCreated = 0
+    var portForwardsCreated = 0
+
+    for (host in hosts) {
+        val connectionId: String
+
+        val existingConnection = connectionStorage.loadConnections().find {
+            it.address == host.hostname && it.port == host.port
+        }
+
+        if (existingConnection != null) {
+            connectionId = existingConnection.id
+        } else if (host.hostname.isNotBlank()) {
+            val identityId: String
+
+            val existingIdentity = host.user?.let { user ->
+                identityStorage.loadIdentities().find { it.username == user }
+            }
+
+            if (existingIdentity != null) {
+                identityId = existingIdentity.id
+            } else {
+                val newIdentity = Identity(
+                    id = UUID.randomUUID().toString(),
+                    nickname = host.user ?: host.nickname,
+                    username = host.user ?: "",
+                    password = null,
+                    privateKeyPath = null,
+                    privateKeyPassphrase = null
+                )
+                identityStorage.addIdentity(newIdentity)
+                identityId = newIdentity.id
+                identitiesCreated++
+            }
+
+            val newConnection = Connection(
+                id = UUID.randomUUID().toString(),
+                nickname = host.nickname,
+                address = host.hostname,
+                port = host.port,
+                identityId = identityId
+            )
+            connectionStorage.addConnection(newConnection)
+            connectionId = newConnection.id
+            connectionsCreated++
+        } else {
+            continue
+        }
+
+        for (fwd in host.localForwards) {
+            val portForward = PortForward(
+                id = UUID.randomUUID().toString(),
+                connectionId = connectionId,
+                nickname = "L${fwd.localPort} -> ${fwd.remoteHost}:${fwd.remotePort}",
+                localPort = fwd.localPort,
+                remoteHost = fwd.remoteHost,
+                remotePort = fwd.remotePort,
+                enabled = true
+            )
+            portForwardStorage.addPortForward(portForward)
+            portForwardsCreated++
+        }
+    }
+
+    val parts = mutableListOf<String>()
+    if (connectionsCreated > 0) parts.add("$connectionsCreated connection(s)")
+    if (identitiesCreated > 0) parts.add("$identitiesCreated identity/ies")
+    if (portForwardsCreated > 0) parts.add("$portForwardsCreated port forward(s)")
+    return if (parts.isEmpty()) "Nothing to import" else "Created: ${parts.joinToString(", ")}"
+}

--- a/app/src/main/java/com/rosi/nectarssh/PortForwardGroupActivity.kt
+++ b/app/src/main/java/com/rosi/nectarssh/PortForwardGroupActivity.kt
@@ -83,6 +83,7 @@ fun PortForwardGroupScreen(
     }
     var expandedConnectionDropdown by remember { mutableStateOf(false) }
     var nickname by remember { mutableStateOf(existingGroup?.nickname ?: "") }
+    var browserUrl by remember { mutableStateOf(existingGroup?.browserUrl ?: "") }
     var selectedPortForwardIds by remember {
         mutableStateOf(existingGroup?.portForwardIds?.toSet() ?: emptySet())
     }
@@ -116,7 +117,8 @@ fun PortForwardGroupScreen(
                                     id = existingGroup?.id ?: UUID.randomUUID().toString(),
                                     connectionId = selectedConnectionId,
                                     nickname = nickname,
-                                    portForwardIds = selectedPortForwardIds.toList()
+                                    portForwardIds = selectedPortForwardIds.toList(),
+                                    browserUrl = browserUrl.ifBlank { null }
                                 )
                                 onSave(group)
                             }
@@ -141,6 +143,16 @@ fun PortForwardGroupScreen(
                 value = nickname,
                 onValueChange = { nickname = it },
                 label = { Text("Group Name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = browserUrl,
+                onValueChange = { browserUrl = it },
+                label = { Text("Browser URL (Optional)") },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true
             )

--- a/app/src/main/java/com/rosi/nectarssh/data/PortForwardGroup.kt
+++ b/app/src/main/java/com/rosi/nectarssh/data/PortForwardGroup.kt
@@ -7,5 +7,6 @@ data class PortForwardGroup(
     val id: String,
     val connectionId: String,
     val nickname: String,
-    val portForwardIds: List<String>
+    val portForwardIds: List<String>,
+    val browserUrl: String? = null
 )

--- a/app/src/main/java/com/rosi/nectarssh/data/SessionState.kt
+++ b/app/src/main/java/com/rosi/nectarssh/data/SessionState.kt
@@ -18,7 +18,8 @@ data class SessionState(
     val notificationId: Int,
     val sequenceNumber: Int,         // Stable sequential number for notification display
     val portForwards: List<PortForward> = emptyList(),
-    val activeForwarderSockets: List<ServerSocket> = emptyList()
+    val activeForwarderSockets: List<ServerSocket> = emptyList(),
+    val groupBrowserUrl: String? = null
 )
 
 enum class ConnectionStatus {

--- a/app/src/main/java/com/rosi/nectarssh/data/SshConfigParser.kt
+++ b/app/src/main/java/com/rosi/nectarssh/data/SshConfigParser.kt
@@ -1,0 +1,134 @@
+package com.rosi.nectarssh.data
+
+data class ParsedSshHost(
+    val nickname: String,
+    val hostname: String,
+    val port: Int = 22,
+    val user: String? = null,
+    val localForwards: List<ParsedLocalForward> = emptyList()
+)
+
+data class ParsedLocalForward(
+    val localPort: Int,
+    val remoteHost: String,
+    val remotePort: Int
+)
+
+object SshConfigParser {
+
+    fun parse(input: String): List<ParsedSshHost> {
+        val hosts = mutableListOf<ParsedSshHost>()
+        var currentNickname: String? = null
+        var hostname: String? = null
+        var port = 22
+        var user: String? = null
+        var forwards = mutableListOf<ParsedLocalForward>()
+
+        fun flushHost() {
+            if (currentNickname != null && hostname != null) {
+                hosts.add(
+                    ParsedSshHost(
+                        nickname = currentNickname!!,
+                        hostname = hostname!!,
+                        port = port,
+                        user = user,
+                        localForwards = forwards.toList()
+                    )
+                )
+            } else if (currentNickname == null && forwards.isNotEmpty()) {
+                hosts.add(
+                    ParsedSshHost(
+                        nickname = hostname ?: "Imported",
+                        hostname = hostname ?: "",
+                        port = port,
+                        user = user,
+                        localForwards = forwards.toList()
+                    )
+                )
+            }
+            currentNickname = null
+            hostname = null
+            port = 22
+            user = null
+            forwards = mutableListOf()
+        }
+
+        for (rawLine in input.lines()) {
+            val line = rawLine.trim()
+            if (line.isEmpty() || line.startsWith("#")) continue
+
+            val parts = line.split("\\s+".toRegex(), limit = 2)
+            if (parts.size < 2) continue
+
+            val directive = parts[0].lowercase()
+            val value = parts[1]
+
+            when (directive) {
+                "host" -> {
+                    flushHost()
+                    currentNickname = value
+                }
+                "hostname" -> hostname = value
+                "port" -> port = value.toIntOrNull() ?: 22
+                "user" -> user = value
+                "localforward" -> {
+                    parseLocalForward(value)?.let { forwards.add(it) }
+                }
+            }
+        }
+
+        flushHost()
+
+        if (hosts.isEmpty()) {
+            val standaloneForwards = mutableListOf<ParsedLocalForward>()
+            for (rawLine in input.lines()) {
+                val line = rawLine.trim()
+                if (line.isEmpty()) continue
+                val forward = parseLocalForwardLine(line)
+                if (forward != null) standaloneForwards.add(forward)
+            }
+            if (standaloneForwards.isNotEmpty()) {
+                hosts.add(
+                    ParsedSshHost(
+                        nickname = "Imported",
+                        hostname = "",
+                        port = 22,
+                        user = null,
+                        localForwards = standaloneForwards
+                    )
+                )
+            }
+        }
+
+        return hosts
+    }
+
+    private fun parseLocalForward(value: String): ParsedLocalForward? {
+        // Format: <localPort> <remoteHost>:<remotePort>
+        // Or: <bindAddress>:<localPort> <remoteHost>:<remotePort>
+        val parts = value.trim().split("\\s+".toRegex(), limit = 2)
+        if (parts.size != 2) return null
+
+        val localPort = parts[0].toIntOrNull()
+            ?: parts[0].substringAfterLast(":").toIntOrNull()
+            ?: return null
+
+        val remote = parts[1]
+        val lastColon = remote.lastIndexOf(':')
+        if (lastColon <= 0) return null
+
+        val remoteHost = remote.substring(0, lastColon)
+        val remotePort = remote.substring(lastColon + 1).toIntOrNull() ?: return null
+
+        return ParsedLocalForward(localPort, remoteHost, remotePort)
+    }
+
+    private fun parseLocalForwardLine(line: String): ParsedLocalForward? {
+        val trimmed = if (line.lowercase().startsWith("localforward")) {
+            line.substringAfter(" ").trim()
+        } else {
+            line
+        }
+        return parseLocalForward(trimmed)
+    }
+}

--- a/app/src/main/java/com/rosi/nectarssh/service/SSHTunnelService.kt
+++ b/app/src/main/java/com/rosi/nectarssh/service/SSHTunnelService.kt
@@ -139,11 +139,13 @@ class SSHTunnelService : Service() {
                 val identity = identityStorage.getIdentity(connection.identityId)
                     ?: throw IllegalArgumentException("Identity not found")
 
+                var groupBrowserUrl: String? = null
                 val portForwards = when {
                     groupId != null -> {
                         val groupStorage = PortForwardGroupStorage(this@SSHTunnelService)
                         val group = groupStorage.getGroup(groupId)
                             ?: throw IllegalArgumentException("Port forward group not found")
+                        groupBrowserUrl = group.browserUrl
                         group.portForwardIds.mapNotNull { portForwardStorage.getPortForward(it) }
                     }
                     portForwardId != null -> {
@@ -173,7 +175,8 @@ class SSHTunnelService : Service() {
                     notificationId = notificationId,
                     sequenceNumber = sequenceNumber,
                     portForwards = portForwards,
-                    activeForwarderSockets = emptyList()
+                    activeForwarderSockets = emptyList(),
+                    groupBrowserUrl = groupBrowserUrl
                 )
 
                 logFlows[sessionId] = MutableSharedFlow(replay = 0)

--- a/app/src/main/java/com/rosi/nectarssh/ui/connection/ConnectionLogScreen.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ui/connection/ConnectionLogScreen.kt
@@ -91,7 +91,13 @@ fun ConnectionLogScreen(
 
             if (newState.status == ConnectionStatus.CONNECTED && previousStatus != ConnectionStatus.CONNECTED && !browserOpened) {
                 browserOpened = true
-                newState.portForwards.forEach { pf ->
+                newState.groupBrowserUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                    try {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                    } catch (e: Exception) {
+                        Toast.makeText(context, "Failed to open browser: ${e.message}", Toast.LENGTH_LONG).show()
+                    }
+                } ?: newState.portForwards.forEach { pf ->
                     pf.browserUrl?.takeIf { it.isNotBlank() }?.let { urlTemplate ->
                         val resolvedUrl = urlTemplate.replace("{localPort}", pf.localPort.toString())
                         try {


### PR DESCRIPTION
## Summary
- Parses SSH config format (Host blocks with LocalForward directives)
- Auto-creates connections, identities, and port forwards
- Matches existing connections/identities to avoid duplicates
- Accessible via upload icon in Manage Connections toolbar

## Test plan
- [ ] Paste a full SSH config block with Host, HostName, User, LocalForward
- [ ] Paste standalone LocalForward lines without Host block
- [ ] Verify existing connections are reused (not duplicated)
- [ ] Verify new identity created when no match found