### PR TITLE
Add desktop shortcut for quick connect

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,13 @@
             android:theme="@style/Theme.NectarSSH"
             android:launchMode="singleTop" />
         <activity
+            android:name="com.rosi.nectarssh.ShortcutLaunchActivity"
+            android:exported="true"
+            android:label="Quick Connect"
+            android:theme="@style/Theme.NectarSSH"
+            android:excludeFromRecents="true"
+            android:taskAffinity="" />
+        <activity
             android:name="com.rosi.nectarssh.ImportActivity"
             android:exported="true"
             android:label="Import Configuration"

--- a/app/src/main/java/com/rosi/nectarssh/ConnectionManageActivity.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ConnectionManageActivity.kt
@@ -3,6 +3,7 @@ package com.rosi.nectarssh
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
@@ -21,15 +22,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AddToHomeScreen
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.PlaylistAdd
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -38,12 +42,14 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,6 +59,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.rosi.nectarssh.data.Connection
 import com.rosi.nectarssh.data.ConnectionStorage
@@ -66,6 +73,7 @@ import com.rosi.nectarssh.data.RecentStorage
 import com.rosi.nectarssh.data.RecentType
 import com.rosi.nectarssh.service.SSHTunnelService
 import com.rosi.nectarssh.ui.theme.NectarSSHTheme
+import com.rosi.nectarssh.util.ShortcutHelper
 import java.util.UUID
 
 class ConnectionManageActivity : ComponentActivity() {
@@ -92,6 +100,11 @@ fun ConnectionManageScreen(onBack: () -> Unit) {
     var identitiesRefresh by remember { mutableStateOf(0) }
 
     val recentStorage = remember { RecentStorage(context) }
+
+    var showShortcutSheet by remember { mutableStateOf(false) }
+    var shortcutLabel by remember { mutableStateOf("") }
+    var shortcutItemId by remember { mutableStateOf("") }
+    var shortcutType by remember { mutableStateOf("") }
 
     val groupLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -241,6 +254,12 @@ fun ConnectionManageScreen(onBack: () -> Unit) {
                     },
                     onGroupDelete = {
                         groupsRefresh++
+                    },
+                    onGroupShortcut = { group ->
+                        shortcutLabel = group.nickname
+                        shortcutItemId = group.id
+                        shortcutType = ShortcutLaunchActivity.TYPE_PORT_FORWARD_GROUP
+                        showShortcutSheet = true
                     }
                 )
                 1 -> PortForwardsTab(
@@ -269,6 +288,12 @@ fun ConnectionManageScreen(onBack: () -> Unit) {
                     },
                     onPortForwardDelete = {
                         portForwardsRefresh++
+                    },
+                    onPortForwardShortcut = { portForward ->
+                        shortcutLabel = portForward.nickname
+                        shortcutItemId = portForward.id
+                        shortcutType = ShortcutLaunchActivity.TYPE_PORT_FORWARD
+                        showShortcutSheet = true
                     }
                 )
                 2 -> ConnectionsTab(
@@ -296,6 +321,12 @@ fun ConnectionManageScreen(onBack: () -> Unit) {
                     },
                     onConnectionDelete = {
                         connectionsRefresh++
+                    },
+                    onConnectionShortcut = { connection ->
+                        shortcutLabel = connection.nickname
+                        shortcutItemId = connection.id
+                        shortcutType = ShortcutLaunchActivity.TYPE_CONNECTION
+                        showShortcutSheet = true
                     }
                 )
                 3 -> IdentitiesTab(
@@ -310,6 +341,73 @@ fun ConnectionManageScreen(onBack: () -> Unit) {
             }
         }
     }
+
+    if (showShortcutSheet) {
+        AddToHomeScreenSheet(
+            label = shortcutLabel,
+            onAdd = {
+                val success = ShortcutHelper.requestPinShortcut(
+                    context = context,
+                    itemId = shortcutItemId,
+                    shortcutType = shortcutType,
+                    label = shortcutLabel
+                )
+                if (!success) {
+                    Toast.makeText(context, "Home screen shortcuts not supported", Toast.LENGTH_SHORT).show()
+                }
+                showShortcutSheet = false
+            },
+            onDismiss = { showShortcutSheet = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddToHomeScreenSheet(
+    label: String,
+    onAdd: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.AddToHomeScreen,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = "Add to Home Screen",
+                style = MaterialTheme.typography.titleLarge
+            )
+            Text(
+                text = "Add \"$label\" as a shortcut on your home screen for quick access.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+                onClick = onAdd,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Add Shortcut")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -318,7 +416,8 @@ fun GroupsTab(
     refreshTrigger: Int,
     onGroupConnect: (PortForwardGroup) -> Unit,
     onGroupEdit: (PortForwardGroup) -> Unit,
-    onGroupDelete: () -> Unit
+    onGroupDelete: () -> Unit,
+    onGroupShortcut: (PortForwardGroup) -> Unit
 ) {
     val context = LocalContext.current
     val groupStorage = remember { PortForwardGroupStorage(context) }
@@ -352,7 +451,8 @@ fun GroupsTab(
                     onDelete = {
                         groupToDelete = group
                         showDeleteDialog = true
-                    }
+                    },
+                    onAddShortcut = { onGroupShortcut(group) }
                 )
             }
         }
@@ -397,7 +497,8 @@ fun GroupListItem(
     portForwardCount: Int,
     onClick: () -> Unit,
     onEdit: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onAddShortcut: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
 
@@ -438,6 +539,13 @@ fun GroupListItem(
                     }
                 )
                 DropdownMenuItem(
+                    text = { Text("Add to Home Screen") },
+                    onClick = {
+                        showMenu = false
+                        onAddShortcut()
+                    }
+                )
+                DropdownMenuItem(
                     text = { Text("Delete") },
                     onClick = {
                         showMenu = false
@@ -454,7 +562,8 @@ fun PortForwardsTab(
     refreshTrigger: Int,
     onPortForwardConnect: (PortForward, Connection) -> Unit,
     onPortForwardEdit: (PortForward) -> Unit,
-    onPortForwardDelete: () -> Unit
+    onPortForwardDelete: () -> Unit,
+    onPortForwardShortcut: (PortForward) -> Unit
 ) {
     val context = LocalContext.current
     val portForwardStorage = remember { PortForwardStorage(context) }
@@ -508,7 +617,8 @@ fun PortForwardsTab(
                         onDelete = {
                             portForwardToDelete = portForward
                             showDeleteDialog = true
-                        }
+                        },
+                        onAddShortcut = { onPortForwardShortcut(portForward) }
                     )
                 }
             }
@@ -553,7 +663,8 @@ fun PortForwardListItem(
     onClick: () -> Unit,
     onEdit: () -> Unit,
     onDuplicate: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onAddShortcut: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
 
@@ -601,6 +712,13 @@ fun PortForwardListItem(
                     }
                 )
                 DropdownMenuItem(
+                    text = { Text("Add to Home Screen") },
+                    onClick = {
+                        showMenu = false
+                        onAddShortcut()
+                    }
+                )
+                DropdownMenuItem(
                     text = { Text("Delete") },
                     onClick = {
                         showMenu = false
@@ -617,7 +735,8 @@ fun ConnectionsTab(
     refreshTrigger: Int,
     onConnectionClick: (Connection) -> Unit,
     onConnectionEdit: (Connection) -> Unit,
-    onConnectionDelete: () -> Unit
+    onConnectionDelete: () -> Unit,
+    onConnectionShortcut: (Connection) -> Unit
 ) {
     val context = LocalContext.current
     val connectionStorage = remember { ConnectionStorage(context) }
@@ -655,7 +774,8 @@ fun ConnectionsTab(
                     onDelete = {
                         connectionToDelete = connection
                         showDeleteDialog = true
-                    }
+                    },
+                    onAddShortcut = { onConnectionShortcut(connection) }
                 )
             }
         }
@@ -687,7 +807,8 @@ fun ConnectionListItem(
     onClick: () -> Unit,
     onEdit: () -> Unit,
     onDuplicate: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onAddShortcut: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
 
@@ -732,6 +853,13 @@ fun ConnectionListItem(
                     onClick = {
                         showMenu = false
                         onDuplicate()
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text("Add to Home Screen") },
+                    onClick = {
+                        showMenu = false
+                        onAddShortcut()
                     }
                 )
                 DropdownMenuItem(

--- a/app/src/main/java/com/rosi/nectarssh/ShortcutLaunchActivity.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ShortcutLaunchActivity.kt
@@ -1,0 +1,110 @@
+package com.rosi.nectarssh
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import com.rosi.nectarssh.data.ConnectionStorage
+import com.rosi.nectarssh.data.PortForwardGroupStorage
+import com.rosi.nectarssh.data.PortForwardStorage
+import com.rosi.nectarssh.data.RecentStorage
+import com.rosi.nectarssh.data.RecentType
+import com.rosi.nectarssh.service.SSHTunnelService
+import java.util.UUID
+
+class ShortcutLaunchActivity : ComponentActivity() {
+
+    companion object {
+        const val EXTRA_SHORTCUT_TYPE = "shortcut_type"
+        const val EXTRA_ITEM_ID = "item_id"
+
+        const val TYPE_CONNECTION = "connection"
+        const val TYPE_PORT_FORWARD = "port_forward"
+        const val TYPE_PORT_FORWARD_GROUP = "port_forward_group"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val shortcutType = intent.getStringExtra(EXTRA_SHORTCUT_TYPE)
+        val itemId = intent.getStringExtra(EXTRA_ITEM_ID)
+
+        if (shortcutType == null || itemId == null) {
+            finish()
+            return
+        }
+
+        when (shortcutType) {
+            TYPE_CONNECTION -> launchConnection(itemId)
+            TYPE_PORT_FORWARD -> launchPortForward(itemId)
+            TYPE_PORT_FORWARD_GROUP -> launchGroup(itemId)
+        }
+
+        finish()
+    }
+
+    private fun launchConnection(connectionId: String) {
+        val connectionStorage = ConnectionStorage(this)
+        val connection = connectionStorage.getConnection(connectionId) ?: return
+
+        val recentStorage = RecentStorage(this)
+        recentStorage.addRecentItem(connection.id, RecentType.CONNECTION)
+
+        val sessionId = UUID.randomUUID().toString()
+        startTunnelService(connection.id, sessionId)
+        openConnectionLog(sessionId)
+    }
+
+    private fun launchPortForward(portForwardId: String) {
+        val portForwardStorage = PortForwardStorage(this)
+        val pf = portForwardStorage.getPortForward(portForwardId) ?: return
+
+        val recentStorage = RecentStorage(this)
+        recentStorage.addRecentItem(pf.id, RecentType.PORT_FORWARD)
+
+        val sessionId = UUID.randomUUID().toString()
+        val serviceIntent = Intent(this, SSHTunnelService::class.java).apply {
+            action = SSHTunnelService.ACTION_START_SESSION
+            putExtra(SSHTunnelService.EXTRA_CONNECTION_ID, pf.connectionId)
+            putExtra(SSHTunnelService.EXTRA_SESSION_ID, sessionId)
+            putExtra(SSHTunnelService.EXTRA_PORT_FORWARD_ID, pf.id)
+        }
+        startService(serviceIntent)
+        openConnectionLog(sessionId)
+    }
+
+    private fun launchGroup(groupId: String) {
+        val groupStorage = PortForwardGroupStorage(this)
+        val group = groupStorage.getGroup(groupId) ?: return
+
+        val recentStorage = RecentStorage(this)
+        recentStorage.addRecentItem(group.id, RecentType.PORT_FORWARD_GROUP)
+
+        val sessionId = UUID.randomUUID().toString()
+        val serviceIntent = Intent(this, SSHTunnelService::class.java).apply {
+            action = SSHTunnelService.ACTION_START_SESSION
+            putExtra(SSHTunnelService.EXTRA_CONNECTION_ID, group.connectionId)
+            putExtra(SSHTunnelService.EXTRA_SESSION_ID, sessionId)
+            putExtra(SSHTunnelService.EXTRA_PORT_FORWARD_GROUP_ID, group.id)
+        }
+        startService(serviceIntent)
+        openConnectionLog(sessionId)
+    }
+
+    private fun startTunnelService(connectionId: String, sessionId: String) {
+        val serviceIntent = Intent(this, SSHTunnelService::class.java).apply {
+            action = SSHTunnelService.ACTION_START_SESSION
+            putExtra(SSHTunnelService.EXTRA_CONNECTION_ID, connectionId)
+            putExtra(SSHTunnelService.EXTRA_SESSION_ID, sessionId)
+        }
+        startService(serviceIntent)
+    }
+
+    private fun openConnectionLog(sessionId: String) {
+        val logIntent = Intent().apply {
+            setClassName(this@ShortcutLaunchActivity, "com.rosi.nectarssh.ui.connection.ConnectionLogActivity")
+            putExtra("session_id", sessionId)
+        }
+        startActivity(logIntent)
+    }
+}

--- a/app/src/main/java/com/rosi/nectarssh/util/ShortcutHelper.kt
+++ b/app/src/main/java/com/rosi/nectarssh/util/ShortcutHelper.kt
@@ -1,0 +1,38 @@
+package com.rosi.nectarssh.util
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.rosi.nectarssh.R
+import com.rosi.nectarssh.ShortcutLaunchActivity
+
+object ShortcutHelper {
+
+    fun requestPinShortcut(
+        context: Context,
+        itemId: String,
+        shortcutType: String,
+        label: String
+    ): Boolean {
+        if (!ShortcutManagerCompat.isRequestPinShortcutSupported(context)) {
+            return false
+        }
+
+        val shortcutIntent = Intent(context, ShortcutLaunchActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            putExtra(ShortcutLaunchActivity.EXTRA_SHORTCUT_TYPE, shortcutType)
+            putExtra(ShortcutLaunchActivity.EXTRA_ITEM_ID, itemId)
+        }
+
+        val shortcutInfo = ShortcutInfoCompat.Builder(context, "nectar_${shortcutType}_$itemId")
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_launcher))
+            .setIntent(shortcutIntent)
+            .build()
+
+        return ShortcutManagerCompat.requestPinShortcut(context, shortcutInfo, null)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds "Add to Home Screen" option to long-press context menus on connections, port forwards, and groups
- Shows a bottom sheet with shortcut details and an "Add Shortcut" button
- Shortcut on home screen launches the SSH tunnel and opens the connection log directly via `ShortcutLaunchActivity`

## Test plan
- [ ] Long-press a connection → verify "Add to Home Screen" appears in menu
- [ ] Tap "Add to Home Screen" → verify bottom sheet shows with correct label
- [ ] Tap "Add Shortcut" → verify system pin-shortcut dialog appears
- [ ] Tap the pinned shortcut → verify tunnel starts and log screen opens
- [ ] Repeat for port forwards and groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)