### PR TITLE
Add interactive terminal emulator

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,10 @@ dependencies {
     // Icons
     implementation("androidx.compose.material:material-icons-extended")
 
+    // Terminal emulator
+    implementation(project(":terminal-emulator"))
+    implementation(project(":terminal-view"))
+
     // SSH library
     implementation("com.hierynomus:sshj:0.39.0")
     implementation("org.slf4j:slf4j-api:2.0.9")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,7 +75,9 @@
             android:exported="false"
             android:label="Connection Logs"
             android:theme="@style/Theme.NectarSSH"
-            android:launchMode="singleTop" />
+            android:launchMode="singleTop"
+            android:windowSoftInputMode="adjustResize"
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden" />
         <activity
             android:name="com.rosi.nectarssh.ShortcutLaunchActivity"
             android:exported="true"

--- a/app/src/main/java/com/rosi/nectarssh/service/SSHTunnelService.kt
+++ b/app/src/main/java/com/rosi/nectarssh/service/SSHTunnelService.kt
@@ -314,7 +314,7 @@ class SSHTunnelService : Service() {
             logToSession(sessionId, LogLevel.INFO, "Authentication successful")
 
             val session = ssh.startSession()
-            session.allocatePTY("vt100", 120, 40, 0, 0, emptyMap())
+            session.allocatePTY("xterm-256color", 50, 30, 0, 0, emptyMap())
             
             updateSessionState(sessionId) { 
                 it.copy(sshClient = ssh, session = session)

--- a/app/src/main/java/com/rosi/nectarssh/service/SSHTunnelService.kt
+++ b/app/src/main/java/com/rosi/nectarssh/service/SSHTunnelService.kt
@@ -151,13 +151,14 @@ class SSHTunnelService : Service() {
                     portForwardId != null -> {
                         listOfNotNull(portForwardStorage.getPortForward(portForwardId))
                     }
-                    else -> {
-                        portForwardStorage.getPortForwardsForConnection(connectionId)
-                            .filter { it.enabled }
-                    }
+                    else -> emptyList()
                 }
 
-                val nickname = portForwards.firstOrNull()?.nickname ?: connection.nickname
+                val nickname = when {
+                    groupId != null -> portForwards.firstOrNull()?.nickname ?: connection.nickname
+                    portForwardId != null -> portForwards.firstOrNull()?.nickname ?: connection.nickname
+                    else -> connection.nickname
+                }
                 val notificationId = notificationIdCounter.getAndIncrement()
                 val sequenceNumber = sessionSequenceCounter.getAndIncrement()
                 
@@ -319,9 +320,6 @@ class SSHTunnelService : Service() {
                 it.copy(sshClient = ssh, session = session)
             }
 
-            // Start capturing remote output before starting shell
-            startCapturingOutput(sessionId, session)
-            
             session.startShell()
 
             val currentPf = activeSessions[sessionId]?.portForwards ?: emptyList()
@@ -451,6 +449,25 @@ class SSHTunnelService : Service() {
     fun getLogFlow(sessionId: String): SharedFlow<LogEntry>? = logFlows[sessionId]
     fun getSessionStateFlow(sessionId: String): SharedFlow<SessionState>? = sessionStateFlows[sessionId]?.asSharedFlow()
     fun getPassphraseRequestFlow(): SharedFlow<PassphraseRequest> = passphraseRequestFlow
+
+    fun getSessionInputStream(sessionId: String): java.io.InputStream? =
+        activeSessions[sessionId]?.session?.inputStream
+
+    fun getSessionOutputStream(sessionId: String): java.io.OutputStream? =
+        activeSessions[sessionId]?.session?.outputStream
+
+    fun resizeTerminal(sessionId: String, cols: Int, rows: Int) {
+        serviceScope.launch(Dispatchers.IO) {
+            val session = activeSessions[sessionId]?.session
+            if (session is net.schmizz.sshj.connection.channel.direct.SessionChannel) {
+                try {
+                    session.changeWindowDimensions(cols, rows, 0, 0)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to resize terminal", e)
+                }
+            }
+        }
+    }
     fun providePassphrase(response: PassphraseResponse) { passphraseResponses[response.sessionId]?.complete(response) }
 
     private fun logToSession(sessionId: String, level: LogLevel, message: String) {

--- a/app/src/main/java/com/rosi/nectarssh/ui/connection/ConnectionLogActivity.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ui/connection/ConnectionLogActivity.kt
@@ -7,11 +7,25 @@ import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import com.rosi.nectarssh.data.ConnectionStatus
 import com.rosi.nectarssh.service.SSHTunnelService
 import com.rosi.nectarssh.ui.theme.NectarSSHTheme
@@ -25,6 +39,8 @@ class ConnectionLogActivity : ComponentActivity() {
     private var tunnelService by mutableStateOf<SSHTunnelService?>(null)
     private var serviceBound = false
     private var sessionId: String? = null
+    private var showTerminal by mutableStateOf(false)
+    private var showDisconnectDialog by mutableStateOf(false)
 
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
@@ -38,6 +54,7 @@ class ConnectionLogActivity : ComponentActivity() {
         }
     }
 
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -48,38 +65,95 @@ class ConnectionLogActivity : ComponentActivity() {
             return
         }
 
-        // Bind to service
         val intent = Intent(this, SSHTunnelService::class.java)
         bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
 
         setContent {
             NectarSSHTheme {
-                ConnectionLogScreen(
-                    sessionId = sessionId!!,
-                    getSessionState = { tunnelService?.getSessionState(sessionId!!) },
-                    getSessionStateFlow = { tunnelService?.getSessionStateFlow(sessionId!!) },
-                    getLogFlow = { tunnelService?.getLogFlow(sessionId!!) },
-                    getPassphraseRequestFlow = { tunnelService?.getPassphraseRequestFlow() },
-                    onPassphraseResponse = { response ->
-                        tunnelService?.providePassphrase(response)
-                    },
-                    onDisconnect = {
-                        tunnelService?.stopSession(sessionId!!)
-                        finish()
-                    },
-                    onKeepRunning = {
-                        finish()
-                    },
-                    onBack = {
-                        handleBack()
+                val service = tunnelService
+                val inputStream = if (showTerminal) service?.getSessionInputStream(sessionId!!) else null
+                val outputStream = if (showTerminal) service?.getSessionOutputStream(sessionId!!) else null
+
+                if (showTerminal && inputStream != null && outputStream != null) {
+                    BackHandler { showDisconnectDialog = true }
+                    Scaffold(
+                        topBar = {
+                            TopAppBar(
+                                title = { Text(service?.getSessionState(sessionId!!)?.nickname ?: "Terminal") },
+                                navigationIcon = {
+                                    IconButton(onClick = { showDisconnectDialog = true }) {
+                                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                    }
+                                }
+                            )
+                        }
+                    ) { padding ->
+                        TerminalScreen(
+                            inputStream = inputStream,
+                            outputStream = outputStream,
+                            onResize = { cols, rows ->
+                                service?.resizeTerminal(sessionId!!, cols, rows)
+                            },
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(padding)
+                        )
                     }
-                )
+
+                    if (showDisconnectDialog) {
+                        AlertDialog(
+                            onDismissRequest = { showDisconnectDialog = false },
+                            title = { Text("Connection Active") },
+                            text = { Text("Keep SSH connection running in background?") },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    showDisconnectDialog = false
+                                    service?.stopSession(sessionId!!)
+                                    finish()
+                                }) { Text("Disconnect") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = {
+                                    showDisconnectDialog = false
+                                    finish()
+                                }) { Text("Keep Running") }
+                            }
+                        )
+                    }
+                } else {
+                    ConnectionLogScreen(
+                        sessionId = sessionId!!,
+                        getSessionState = { service?.getSessionState(sessionId!!) },
+                        getSessionStateFlow = { service?.getSessionStateFlow(sessionId!!) },
+                        getLogFlow = { service?.getLogFlow(sessionId!!) },
+                        getPassphraseRequestFlow = { service?.getPassphraseRequestFlow() },
+                        onPassphraseResponse = { response ->
+                            service?.providePassphrase(response)
+                        },
+                        onDisconnect = {
+                            service?.stopSession(sessionId!!)
+                            finish()
+                        },
+                        onKeepRunning = {
+                            finish()
+                        },
+                        onBack = {
+                            handleBack()
+                        },
+                        onConnected = {
+                            android.util.Log.d("NectarTerminal", "onConnected called, switching to terminal")
+                            showTerminal = true
+                        },
+                        serviceReady = service != null
+                    )
+                }
             }
         }
     }
 
     private fun handleBack() {
         val sessionState = tunnelService?.getSessionState(sessionId!!)
+        android.util.Log.d("NectarTerminal", "handleBack called, status=${sessionState?.status}")
         if (sessionState?.status == ConnectionStatus.CONNECTED || sessionState?.status == ConnectionStatus.CONNECTING) {
             // Will be handled by ConnectionLogScreen's dialog
         } else {

--- a/app/src/main/java/com/rosi/nectarssh/ui/connection/ConnectionLogScreen.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ui/connection/ConnectionLogScreen.kt
@@ -47,7 +47,9 @@ fun ConnectionLogScreen(
     onPassphraseResponse: (PassphraseResponse) -> Unit,
     onDisconnect: () -> Unit,
     onKeepRunning: () -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onConnected: (() -> Unit)? = null,
+    serviceReady: Boolean = true
 ) {
     val context = LocalContext.current
     var sessionState by remember { mutableStateOf<SessionState?>(null) }
@@ -59,7 +61,9 @@ fun ConnectionLogScreen(
     var currentPassphraseRequest by remember { mutableStateOf<PassphraseRequest?>(null) }
 
     // Initial load with timeout
-    LaunchedEffect(sessionId) {
+    LaunchedEffect(sessionId, serviceReady) {
+        if (!serviceReady) return@LaunchedEffect
+        loadingFailed = false
         var attempts = 0
         while (attempts < 20 && sessionState == null && !loadingFailed) {
             val initialState = getSessionState()
@@ -81,7 +85,8 @@ fun ConnectionLogScreen(
     }
 
     // Collect session state updates via Flow
-    LaunchedEffect(sessionId) {
+    LaunchedEffect(sessionId, serviceReady) {
+        if (!serviceReady) return@LaunchedEffect
         val stateFlow = getSessionStateFlow()
         stateFlow?.collect { newState ->
             loadingFailed = false // Reset failed state if we get updates
@@ -107,10 +112,12 @@ fun ConnectionLogScreen(
                         }
                     }
                 }
+                onConnected?.invoke()
             }
 
             // Auto-finish activity if disconnected from external source (like notification)
             if (newState.status == ConnectionStatus.DISCONNECTED) {
+                android.util.Log.d("NectarTerminal", "Auto-finish: status DISCONNECTED")
                 onBack()
             }
 

--- a/app/src/main/java/com/rosi/nectarssh/ui/connection/TerminalScreen.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ui/connection/TerminalScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -79,7 +80,10 @@ fun TerminalScreen(
         }
     }
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(modifier = modifier
+        .fillMaxSize()
+        .imePadding()
+    ) {
         Box(
             modifier = Modifier
                 .weight(1f)

--- a/app/src/main/java/com/rosi/nectarssh/ui/connection/TerminalScreen.kt
+++ b/app/src/main/java/com/rosi/nectarssh/ui/connection/TerminalScreen.kt
@@ -1,0 +1,180 @@
+package com.rosi.nectarssh.ui.connection
+
+import android.util.Log
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.inputmethod.InputMethodManager
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.termux.terminal.TerminalSession
+import com.termux.terminal.TerminalSessionClient
+import com.termux.view.TerminalView
+import com.termux.view.TerminalViewClient
+import java.io.InputStream
+import java.io.OutputStream
+
+@Composable
+fun TerminalScreen(
+    inputStream: InputStream,
+    outputStream: OutputStream,
+    onResize: ((cols: Int, rows: Int) -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    var terminalViewRef by remember { mutableStateOf<TerminalView?>(null) }
+
+    val sessionClient = remember {
+        object : TerminalSessionClient {
+            override fun onTextChanged(changedSession: TerminalSession) {
+                terminalViewRef?.invalidate()
+            }
+            override fun onTitleChanged(changedSession: TerminalSession) {}
+            override fun onSessionFinished(finishedSession: TerminalSession) {}
+            override fun onCopyTextToClipboard(session: TerminalSession, text: String?) {}
+            override fun onPasteTextFromClipboard(session: TerminalSession?) {}
+            override fun onBell(session: TerminalSession) {}
+            override fun onColorsChanged(session: TerminalSession) {}
+            override fun onTerminalCursorStateChange(state: Boolean) {}
+            override fun setTerminalShellPid(session: TerminalSession, pid: Int) {}
+            override fun getTerminalCursorStyle(): Int = 0
+            override fun logError(tag: String?, message: String?) { Log.e(tag ?: "Terminal", message ?: "") }
+            override fun logWarn(tag: String?, message: String?) { Log.w(tag ?: "Terminal", message ?: "") }
+            override fun logInfo(tag: String?, message: String?) { Log.i(tag ?: "Terminal", message ?: "") }
+            override fun logDebug(tag: String?, message: String?) { Log.d(tag ?: "Terminal", message ?: "") }
+            override fun logVerbose(tag: String?, message: String?) { Log.v(tag ?: "Terminal", message ?: "") }
+            override fun logStackTraceWithMessage(tag: String?, message: String?, e: Exception?) {
+                Log.e(tag ?: "Terminal", message, e)
+            }
+            override fun logStackTrace(tag: String?, e: Exception?) {
+                Log.e(tag ?: "Terminal", "Exception", e)
+            }
+        }
+    }
+
+    val terminalSession = remember {
+        TerminalSession(inputStream, outputStream, null, sessionClient).also { session ->
+            if (onResize != null) {
+                session.setOnResizeListener { cols, rows -> onResize(cols, rows) }
+            }
+        }
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .background(Color.Black)
+        ) {
+            AndroidView(
+                factory = { ctx ->
+                    TerminalView(ctx, null).apply {
+                        val scaledSize = (14 * ctx.resources.displayMetrics.scaledDensity).toInt()
+                        setTextSize(scaledSize)
+                        setTerminalViewClient(object : TerminalViewClient {
+                            override fun onScale(scale: Float): Float = 1.0f
+                            override fun onSingleTapUp(e: MotionEvent?) {
+                                val imm = ctx.getSystemService(InputMethodManager::class.java)
+                                imm?.showSoftInput(this@apply, InputMethodManager.SHOW_IMPLICIT)
+                            }
+                            override fun shouldBackButtonBeMappedToEscape(): Boolean = false
+                            override fun shouldEnforceCharBasedInput(): Boolean = true
+                            override fun shouldUseCtrlSpaceWorkaround(): Boolean = false
+                            override fun isTerminalViewSelected(): Boolean = true
+                            override fun copyModeChanged(copyMode: Boolean) {}
+                            override fun onKeyDown(keyCode: Int, e: KeyEvent?, session: TerminalSession?): Boolean = false
+                            override fun onKeyUp(keyCode: Int, e: KeyEvent?): Boolean = false
+                            override fun onLongPress(event: MotionEvent?): Boolean = false
+                            override fun readControlKey(): Boolean = false
+                            override fun readAltKey(): Boolean = false
+                            override fun readShiftKey(): Boolean = false
+                            override fun readFnKey(): Boolean = false
+                            override fun onCodePoint(codePoint: Int, ctrlDown: Boolean, session: TerminalSession?): Boolean = false
+                            override fun onEmulatorSet() {}
+                            override fun logError(tag: String?, message: String?) {}
+                            override fun logWarn(tag: String?, message: String?) {}
+                            override fun logInfo(tag: String?, message: String?) {}
+                            override fun logDebug(tag: String?, message: String?) {}
+                            override fun logVerbose(tag: String?, message: String?) {}
+                            override fun logStackTraceWithMessage(tag: String?, message: String?, e: Exception?) {}
+                            override fun logStackTrace(tag: String?, e: Exception?) {}
+                        })
+                        attachSession(terminalSession)
+                        terminalViewRef = this
+                        post {
+                            if (width > 0 && height > 0) {
+                                updateSize()
+                                requestFocus()
+                            }
+                        }
+                        isFocusable = true
+                        isFocusableInTouchMode = true
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+
+        ExtraKeysRow(
+            onKey = { key -> terminalSession.write(key.toByteArray(), 0, key.length) }
+        )
+    }
+}
+
+@Composable
+fun ExtraKeysRow(onKey: (String) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(4.dp)
+    ) {
+        val keys = listOf(
+            "ESC" to "",
+            "TAB" to "\t",
+            "↑" to "[A",
+            "↓" to "[B",
+            "←" to "[D",
+            "→" to "[C",
+            "/" to "/",
+            "|" to "|",
+            "~" to "~",
+            "-" to "-"
+        )
+
+        keys.forEach { (label, value) ->
+            TextButton(
+                onClick = { onKey(value) },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(40.dp)
+            ) {
+                Text(
+                    text = label,
+                    fontSize = 11.sp,
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "NectarSSH"
 include(":app")
+include(":terminal-emulator")
+include(":terminal-view")

--- a/terminal-emulator/build.gradle
+++ b/terminal-emulator/build.gradle
@@ -1,0 +1,26 @@
+apply plugin: 'com.android.library'
+
+android {
+    namespace "com.termux.emulator"
+    compileSdk 36
+
+    defaultConfig {
+        minSdk 24
+        targetSdk 36
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation "androidx.annotation:annotation:1.9.0"
+}

--- a/terminal-emulator/proguard-rules.pro
+++ b/terminal-emulator/proguard-rules.pro
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /Users/fornwall/lib/android-sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/terminal-emulator/src/main/AndroidManifest.xml
+++ b/terminal-emulator/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/terminal-emulator/src/main/java/com/termux/terminal/ByteQueue.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/ByteQueue.java
@@ -1,0 +1,108 @@
+package com.termux.terminal;
+
+/** A circular byte buffer allowing one producer and one consumer thread. */
+final class ByteQueue {
+
+    private final byte[] mBuffer;
+    private int mHead;
+    private int mStoredBytes;
+    private boolean mOpen = true;
+
+    public ByteQueue(int size) {
+        mBuffer = new byte[size];
+    }
+
+    public synchronized void close() {
+        mOpen = false;
+        notify();
+    }
+
+    public synchronized int read(byte[] buffer, boolean block) {
+        while (mStoredBytes == 0 && mOpen) {
+            if (block) {
+                try {
+                    wait();
+                } catch (InterruptedException e) {
+                    // Ignore.
+                }
+            } else {
+                return 0;
+            }
+        }
+        if (!mOpen) return -1;
+
+        int totalRead = 0;
+        int bufferLength = mBuffer.length;
+        boolean wasFull = bufferLength == mStoredBytes;
+        int length = buffer.length;
+        int offset = 0;
+        while (length > 0 && mStoredBytes > 0) {
+            int oneRun = Math.min(bufferLength - mHead, mStoredBytes);
+            int bytesToCopy = Math.min(length, oneRun);
+            System.arraycopy(mBuffer, mHead, buffer, offset, bytesToCopy);
+            mHead += bytesToCopy;
+            if (mHead >= bufferLength) mHead = 0;
+            mStoredBytes -= bytesToCopy;
+            length -= bytesToCopy;
+            offset += bytesToCopy;
+            totalRead += bytesToCopy;
+        }
+        if (wasFull) notify();
+        return totalRead;
+    }
+
+    /**
+     * Attempt to write the specified portion of the provided buffer to the queue.
+     * <p/>
+     * Returns whether the output was totally written, false if it was closed before.
+     */
+    public boolean write(byte[] buffer, int offset, int lengthToWrite) {
+        if (lengthToWrite + offset > buffer.length) {
+            throw new IllegalArgumentException("length + offset > buffer.length");
+        } else if (lengthToWrite <= 0) {
+            throw new IllegalArgumentException("length <= 0");
+        }
+
+        final int bufferLength = mBuffer.length;
+
+        synchronized (this) {
+            while (lengthToWrite > 0) {
+                while (bufferLength == mStoredBytes && mOpen) {
+                    try {
+                        wait();
+                    } catch (InterruptedException e) {
+                        // Ignore.
+                    }
+                }
+                if (!mOpen) return false;
+                final boolean wasEmpty = mStoredBytes == 0;
+                int bytesToWriteBeforeWaiting = Math.min(lengthToWrite, bufferLength - mStoredBytes);
+                lengthToWrite -= bytesToWriteBeforeWaiting;
+
+                while (bytesToWriteBeforeWaiting > 0) {
+                    int tail = mHead + mStoredBytes;
+                    int oneRun;
+                    if (tail >= bufferLength) {
+                        // Buffer: [.............]
+                        // ________________H_______T
+                        // =>
+                        // Buffer: [.............]
+                        // ___________T____H
+                        // onRun= _____----_
+                        tail = tail - bufferLength;
+                        oneRun = mHead - tail;
+                    } else {
+                        oneRun = bufferLength - tail;
+                    }
+                    int bytesToCopy = Math.min(oneRun, bytesToWriteBeforeWaiting);
+                    System.arraycopy(buffer, offset, mBuffer, tail, bytesToCopy);
+                    offset += bytesToCopy;
+                    bytesToWriteBeforeWaiting -= bytesToCopy;
+                    mStoredBytes += bytesToCopy;
+                }
+                if (wasEmpty) notify();
+            }
+        }
+        return true;
+    }
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/JNI.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/JNI.java
@@ -1,0 +1,25 @@
+package com.termux.terminal;
+
+/**
+ * Stub for native methods. Not used in NectarSSH (we use SSH streams instead of local PTY).
+ * Kept to avoid modifying other Termux source files that reference this class.
+ */
+final class JNI {
+
+    public static int createSubprocess(String cmd, String cwd, String[] args, String[] envVars, int[] processId, int rows, int columns, int cellWidth, int cellHeight) {
+        throw new UnsupportedOperationException("Local subprocess not supported - use SSH streams");
+    }
+
+    public static void setPtyWindowSize(int fd, int rows, int cols, int cellWidth, int cellHeight) {
+        // No-op for SSH mode
+    }
+
+    public static int waitFor(int processId) {
+        throw new UnsupportedOperationException("Local subprocess not supported - use SSH streams");
+    }
+
+    public static void close(int fileDescriptor) {
+        // No-op for SSH mode
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/KeyHandler.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/KeyHandler.java
@@ -1,0 +1,373 @@
+package com.termux.terminal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static android.view.KeyEvent.KEYCODE_BACK;
+import static android.view.KeyEvent.KEYCODE_BREAK;
+import static android.view.KeyEvent.KEYCODE_DEL;
+import static android.view.KeyEvent.KEYCODE_DPAD_CENTER;
+import static android.view.KeyEvent.KEYCODE_DPAD_DOWN;
+import static android.view.KeyEvent.KEYCODE_DPAD_LEFT;
+import static android.view.KeyEvent.KEYCODE_DPAD_RIGHT;
+import static android.view.KeyEvent.KEYCODE_DPAD_UP;
+import static android.view.KeyEvent.KEYCODE_ENTER;
+import static android.view.KeyEvent.KEYCODE_ESCAPE;
+import static android.view.KeyEvent.KEYCODE_F1;
+import static android.view.KeyEvent.KEYCODE_F10;
+import static android.view.KeyEvent.KEYCODE_F11;
+import static android.view.KeyEvent.KEYCODE_F12;
+import static android.view.KeyEvent.KEYCODE_F2;
+import static android.view.KeyEvent.KEYCODE_F3;
+import static android.view.KeyEvent.KEYCODE_F4;
+import static android.view.KeyEvent.KEYCODE_F5;
+import static android.view.KeyEvent.KEYCODE_F6;
+import static android.view.KeyEvent.KEYCODE_F7;
+import static android.view.KeyEvent.KEYCODE_F8;
+import static android.view.KeyEvent.KEYCODE_F9;
+import static android.view.KeyEvent.KEYCODE_FORWARD_DEL;
+import static android.view.KeyEvent.KEYCODE_INSERT;
+import static android.view.KeyEvent.KEYCODE_MOVE_END;
+import static android.view.KeyEvent.KEYCODE_MOVE_HOME;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_0;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_1;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_2;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_3;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_4;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_5;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_6;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_7;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_8;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_9;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_ADD;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_COMMA;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_DIVIDE;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_DOT;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_ENTER;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_EQUALS;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_MULTIPLY;
+import static android.view.KeyEvent.KEYCODE_NUMPAD_SUBTRACT;
+import static android.view.KeyEvent.KEYCODE_NUM_LOCK;
+import static android.view.KeyEvent.KEYCODE_PAGE_DOWN;
+import static android.view.KeyEvent.KEYCODE_PAGE_UP;
+import static android.view.KeyEvent.KEYCODE_SPACE;
+import static android.view.KeyEvent.KEYCODE_SYSRQ;
+import static android.view.KeyEvent.KEYCODE_TAB;
+
+public final class KeyHandler {
+
+    public static final int KEYMOD_ALT = 0x80000000;
+    public static final int KEYMOD_CTRL = 0x40000000;
+    public static final int KEYMOD_SHIFT = 0x20000000;
+    public static final int KEYMOD_NUM_LOCK = 0x10000000;
+
+    private static final Map<String, Integer> TERMCAP_TO_KEYCODE = new HashMap<>();
+
+    static {
+        // terminfo: http://pubs.opengroup.org/onlinepubs/7990989799/xcurses/terminfo.html
+        // termcap: http://man7.org/linux/man-pages/man5/termcap.5.html
+        TERMCAP_TO_KEYCODE.put("%i", KEYMOD_SHIFT | KEYCODE_DPAD_RIGHT);
+        TERMCAP_TO_KEYCODE.put("#2", KEYMOD_SHIFT | KEYCODE_MOVE_HOME); // Shifted home
+        TERMCAP_TO_KEYCODE.put("#4", KEYMOD_SHIFT | KEYCODE_DPAD_LEFT);
+        TERMCAP_TO_KEYCODE.put("*7", KEYMOD_SHIFT | KEYCODE_MOVE_END); // Shifted end key
+
+        TERMCAP_TO_KEYCODE.put("k1", KEYCODE_F1);
+        TERMCAP_TO_KEYCODE.put("k2", KEYCODE_F2);
+        TERMCAP_TO_KEYCODE.put("k3", KEYCODE_F3);
+        TERMCAP_TO_KEYCODE.put("k4", KEYCODE_F4);
+        TERMCAP_TO_KEYCODE.put("k5", KEYCODE_F5);
+        TERMCAP_TO_KEYCODE.put("k6", KEYCODE_F6);
+        TERMCAP_TO_KEYCODE.put("k7", KEYCODE_F7);
+        TERMCAP_TO_KEYCODE.put("k8", KEYCODE_F8);
+        TERMCAP_TO_KEYCODE.put("k9", KEYCODE_F9);
+        TERMCAP_TO_KEYCODE.put("k;", KEYCODE_F10);
+        TERMCAP_TO_KEYCODE.put("F1", KEYCODE_F11);
+        TERMCAP_TO_KEYCODE.put("F2", KEYCODE_F12);
+        TERMCAP_TO_KEYCODE.put("F3", KEYMOD_SHIFT | KEYCODE_F1);
+        TERMCAP_TO_KEYCODE.put("F4", KEYMOD_SHIFT | KEYCODE_F2);
+        TERMCAP_TO_KEYCODE.put("F5", KEYMOD_SHIFT | KEYCODE_F3);
+        TERMCAP_TO_KEYCODE.put("F6", KEYMOD_SHIFT | KEYCODE_F4);
+        TERMCAP_TO_KEYCODE.put("F7", KEYMOD_SHIFT | KEYCODE_F5);
+        TERMCAP_TO_KEYCODE.put("F8", KEYMOD_SHIFT | KEYCODE_F6);
+        TERMCAP_TO_KEYCODE.put("F9", KEYMOD_SHIFT | KEYCODE_F7);
+        TERMCAP_TO_KEYCODE.put("FA", KEYMOD_SHIFT | KEYCODE_F8);
+        TERMCAP_TO_KEYCODE.put("FB", KEYMOD_SHIFT | KEYCODE_F9);
+        TERMCAP_TO_KEYCODE.put("FC", KEYMOD_SHIFT | KEYCODE_F10);
+        TERMCAP_TO_KEYCODE.put("FD", KEYMOD_SHIFT | KEYCODE_F11);
+        TERMCAP_TO_KEYCODE.put("FE", KEYMOD_SHIFT | KEYCODE_F12);
+
+        TERMCAP_TO_KEYCODE.put("kb", KEYCODE_DEL); // backspace key
+
+        TERMCAP_TO_KEYCODE.put("kd", KEYCODE_DPAD_DOWN); // terminfo=kcud1, down-arrow key
+        TERMCAP_TO_KEYCODE.put("kh", KEYCODE_MOVE_HOME);
+        TERMCAP_TO_KEYCODE.put("kl", KEYCODE_DPAD_LEFT);
+        TERMCAP_TO_KEYCODE.put("kr", KEYCODE_DPAD_RIGHT);
+
+        // K1=Upper left of keypad:
+        // t_K1 <kHome> keypad home key
+        // t_K3 <kPageUp> keypad page-up key
+        // t_K4 <kEnd> keypad end key
+        // t_K5 <kPageDown> keypad page-down key
+        TERMCAP_TO_KEYCODE.put("K1", KEYCODE_MOVE_HOME);
+        TERMCAP_TO_KEYCODE.put("K3", KEYCODE_PAGE_UP);
+        TERMCAP_TO_KEYCODE.put("K4", KEYCODE_MOVE_END);
+        TERMCAP_TO_KEYCODE.put("K5", KEYCODE_PAGE_DOWN);
+
+        TERMCAP_TO_KEYCODE.put("ku", KEYCODE_DPAD_UP);
+
+        TERMCAP_TO_KEYCODE.put("kB", KEYMOD_SHIFT | KEYCODE_TAB); // termcap=kB, terminfo=kcbt: Back-tab
+        TERMCAP_TO_KEYCODE.put("kD", KEYCODE_FORWARD_DEL); // terminfo=kdch1, delete-character key
+        TERMCAP_TO_KEYCODE.put("kDN", KEYMOD_SHIFT | KEYCODE_DPAD_DOWN); // non-standard shifted arrow down
+        TERMCAP_TO_KEYCODE.put("kF", KEYMOD_SHIFT | KEYCODE_DPAD_DOWN); // terminfo=kind, scroll-forward key
+        TERMCAP_TO_KEYCODE.put("kI", KEYCODE_INSERT);
+        TERMCAP_TO_KEYCODE.put("kP", KEYCODE_PAGE_UP);
+        TERMCAP_TO_KEYCODE.put("kN", KEYCODE_PAGE_DOWN);
+        TERMCAP_TO_KEYCODE.put("kR", KEYMOD_SHIFT | KEYCODE_DPAD_UP); // terminfo=kri, scroll-backward key
+        TERMCAP_TO_KEYCODE.put("kUP", KEYMOD_SHIFT | KEYCODE_DPAD_UP); // non-standard shifted up
+
+        TERMCAP_TO_KEYCODE.put("@7", KEYCODE_MOVE_END);
+        TERMCAP_TO_KEYCODE.put("@8", KEYCODE_NUMPAD_ENTER);
+    }
+
+    static String getCodeFromTermcap(String termcap, boolean cursorKeysApplication, boolean keypadApplication) {
+        Integer keyCodeAndMod = TERMCAP_TO_KEYCODE.get(termcap);
+        if (keyCodeAndMod == null) return null;
+        int keyCode = keyCodeAndMod;
+        int keyMod = 0;
+        if ((keyCode & KEYMOD_SHIFT) != 0) {
+            keyMod |= KEYMOD_SHIFT;
+            keyCode &= ~KEYMOD_SHIFT;
+        }
+        if ((keyCode & KEYMOD_CTRL) != 0) {
+            keyMod |= KEYMOD_CTRL;
+            keyCode &= ~KEYMOD_CTRL;
+        }
+        if ((keyCode & KEYMOD_ALT) != 0) {
+            keyMod |= KEYMOD_ALT;
+            keyCode &= ~KEYMOD_ALT;
+        }
+        if ((keyCode & KEYMOD_NUM_LOCK) != 0) {
+            keyMod |= KEYMOD_NUM_LOCK;
+            keyCode &= ~KEYMOD_NUM_LOCK;
+        }
+        return getCode(keyCode, keyMod, cursorKeysApplication, keypadApplication);
+    }
+
+    public static String getCode(int keyCode, int keyMode, boolean cursorApp, boolean keypadApplication) {
+        boolean numLockOn = (keyMode & KEYMOD_NUM_LOCK) != 0;
+        keyMode &= ~KEYMOD_NUM_LOCK;
+        switch (keyCode) {
+            case KEYCODE_DPAD_CENTER:
+                return "\015";
+
+            case KEYCODE_DPAD_UP:
+                return (keyMode == 0) ? (cursorApp ? "\033OA" : "\033[A") : transformForModifiers("\033[1", keyMode, 'A');
+            case KEYCODE_DPAD_DOWN:
+                return (keyMode == 0) ? (cursorApp ? "\033OB" : "\033[B") : transformForModifiers("\033[1", keyMode, 'B');
+            case KEYCODE_DPAD_RIGHT:
+                return (keyMode == 0) ? (cursorApp ? "\033OC" : "\033[C") : transformForModifiers("\033[1", keyMode, 'C');
+            case KEYCODE_DPAD_LEFT:
+                return (keyMode == 0) ? (cursorApp ? "\033OD" : "\033[D") : transformForModifiers("\033[1", keyMode, 'D');
+
+            case KEYCODE_MOVE_HOME:
+                // Note that KEYCODE_HOME is handled by the system and never delivered to applications.
+                // On a Logitech k810 keyboard KEYCODE_MOVE_HOME is sent by FN+LeftArrow.
+                return (keyMode == 0) ? (cursorApp ? "\033OH" : "\033[H") : transformForModifiers("\033[1", keyMode, 'H');
+            case KEYCODE_MOVE_END:
+                return (keyMode == 0) ? (cursorApp ? "\033OF" : "\033[F") : transformForModifiers("\033[1", keyMode, 'F');
+
+            // An xterm can send function keys F1 to F4 in two modes: vt100 compatible or
+            // not. Because Vim may not know what the xterm is sending, both types of keys
+            // are recognized. The same happens for the <Home> and <End> keys.
+            // normal vt100 ~
+            // <F1> t_k1 <Esc>[11~ <xF1> <Esc>OP *<xF1>-xterm*
+            // <F2> t_k2 <Esc>[12~ <xF2> <Esc>OQ *<xF2>-xterm*
+            // <F3> t_k3 <Esc>[13~ <xF3> <Esc>OR *<xF3>-xterm*
+            // <F4> t_k4 <Esc>[14~ <xF4> <Esc>OS *<xF4>-xterm*
+            // <Home> t_kh <Esc>[7~ <xHome> <Esc>OH *<xHome>-xterm*
+            // <End> t_@7 <Esc>[4~ <xEnd> <Esc>OF *<xEnd>-xterm*
+            case KEYCODE_F1:
+                return (keyMode == 0) ? "\033OP" : transformForModifiers("\033[1", keyMode, 'P');
+            case KEYCODE_F2:
+                return (keyMode == 0) ? "\033OQ" : transformForModifiers("\033[1", keyMode, 'Q');
+            case KEYCODE_F3:
+                return (keyMode == 0) ? "\033OR" : transformForModifiers("\033[1", keyMode, 'R');
+            case KEYCODE_F4:
+                return (keyMode == 0) ? "\033OS" : transformForModifiers("\033[1", keyMode, 'S');
+            case KEYCODE_F5:
+                return transformForModifiers("\033[15", keyMode, '~');
+            case KEYCODE_F6:
+                return transformForModifiers("\033[17", keyMode, '~');
+            case KEYCODE_F7:
+                return transformForModifiers("\033[18", keyMode, '~');
+            case KEYCODE_F8:
+                return transformForModifiers("\033[19", keyMode, '~');
+            case KEYCODE_F9:
+                return transformForModifiers("\033[20", keyMode, '~');
+            case KEYCODE_F10:
+                return transformForModifiers("\033[21", keyMode, '~');
+            case KEYCODE_F11:
+                return transformForModifiers("\033[23", keyMode, '~');
+            case KEYCODE_F12:
+                return transformForModifiers("\033[24", keyMode, '~');
+
+            case KEYCODE_SYSRQ:
+                return "\033[32~"; // Sys Request / Print
+            // Is this Scroll lock? case Cancel: return "\033[33~";
+            case KEYCODE_BREAK:
+                return "\033[34~"; // Pause/Break
+
+            case KEYCODE_ESCAPE:
+            case KEYCODE_BACK:
+                return "\033";
+
+            case KEYCODE_INSERT:
+                return transformForModifiers("\033[2", keyMode, '~');
+            case KEYCODE_FORWARD_DEL:
+                return transformForModifiers("\033[3", keyMode, '~');
+
+            case KEYCODE_PAGE_UP:
+                return transformForModifiers("\033[5", keyMode, '~');
+            case KEYCODE_PAGE_DOWN:
+                return transformForModifiers("\033[6", keyMode, '~');
+            case KEYCODE_DEL:
+                String prefix = ((keyMode & KEYMOD_ALT) == 0) ? "" : "\033";
+                // Just do what xterm and gnome-terminal does:
+                return prefix + (((keyMode & KEYMOD_CTRL) == 0) ? "\u007F" : "\u0008");
+            case KEYCODE_NUM_LOCK:
+                if (keypadApplication) {
+                    return "\033OP";
+                } else {
+                    return null;
+                }
+            case KEYCODE_SPACE:
+                // If ctrl is not down, return null so that it goes through normal input processing (which may e.g. cause a
+                // combining accent to be written):
+                return ((keyMode & KEYMOD_CTRL) == 0) ? null : "\0";
+            case KEYCODE_TAB:
+                // This is back-tab when shifted:
+                return (keyMode & KEYMOD_SHIFT) == 0 ? "\011" : "\033[Z";
+            case KEYCODE_ENTER:
+                return ((keyMode & KEYMOD_ALT) == 0) ? "\r" : "\033\r";
+
+            case KEYCODE_NUMPAD_ENTER:
+                return keypadApplication ? transformForModifiers("\033O", keyMode, 'M') : "\n";
+            case KEYCODE_NUMPAD_MULTIPLY:
+                return keypadApplication ? transformForModifiers("\033O", keyMode, 'j') : "*";
+            case KEYCODE_NUMPAD_ADD:
+                return keypadApplication ? transformForModifiers("\033O", keyMode, 'k') : "+";
+            case KEYCODE_NUMPAD_COMMA:
+                return ",";
+            case KEYCODE_NUMPAD_DOT:
+                if (numLockOn) {
+                    return keypadApplication ? "\033On" : ".";
+                } else {
+                    // DELETE
+                    return transformForModifiers("\033[3", keyMode, '~');
+                }
+            case KEYCODE_NUMPAD_SUBTRACT:
+                return keypadApplication ? transformForModifiers("\033O", keyMode, 'm') : "-";
+            case KEYCODE_NUMPAD_DIVIDE:
+                return keypadApplication ? transformForModifiers("\033O", keyMode, 'o') : "/";
+            case KEYCODE_NUMPAD_0:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 'p') : "0";
+                } else {
+                    // INSERT
+                    return transformForModifiers("\033[2", keyMode, '~');
+                }
+            case KEYCODE_NUMPAD_1:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 'q') : "1";
+                } else {
+                    // END
+                    return (keyMode == 0) ? (cursorApp ? "\033OF" : "\033[F") : transformForModifiers("\033[1", keyMode, 'F');
+                }
+            case KEYCODE_NUMPAD_2:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 'r') : "2";
+                } else {
+                    // DOWN
+                    return (keyMode == 0) ? (cursorApp ? "\033OB" : "\033[B") : transformForModifiers("\033[1", keyMode, 'B');
+                }
+            case KEYCODE_NUMPAD_3:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 's') : "3";
+                } else {
+                    // PGDN
+                    return "\033[6~";
+                }
+            case KEYCODE_NUMPAD_4:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 't') : "4";
+                } else {
+                    // LEFT
+                    return (keyMode == 0) ? (cursorApp ? "\033OD" : "\033[D") : transformForModifiers("\033[1", keyMode, 'D');
+                }
+            case KEYCODE_NUMPAD_5:
+                return keypadApplication ? transformForModifiers("\033O", keyMode, 'u') : "5";
+            case KEYCODE_NUMPAD_6:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 'v') : "6";
+                } else {
+                    // RIGHT
+                    return (keyMode == 0) ? (cursorApp ? "\033OC" : "\033[C") : transformForModifiers("\033[1", keyMode, 'C');
+                }
+            case KEYCODE_NUMPAD_7:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 'w') : "7";
+                } else {
+                    // HOME
+                    return (keyMode == 0) ? (cursorApp ? "\033OH" : "\033[H") : transformForModifiers("\033[1", keyMode, 'H');
+                }
+            case KEYCODE_NUMPAD_8:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 'x') : "8";
+                } else {
+                    // UP
+                    return (keyMode == 0) ? (cursorApp ? "\033OA" : "\033[A") : transformForModifiers("\033[1", keyMode, 'A');
+                }
+            case KEYCODE_NUMPAD_9:
+                if (numLockOn) {
+                    return keypadApplication ? transformForModifiers("\033O", keyMode, 'y') : "9";
+                } else {
+                    // PGUP
+                    return "\033[5~";
+                }
+            case KEYCODE_NUMPAD_EQUALS:
+                return keypadApplication ? transformForModifiers("\033O", keyMode, 'X') : "=";
+        }
+
+        return null;
+    }
+
+    private static String transformForModifiers(String start, int keymod, char lastChar) {
+        int modifier;
+        switch (keymod) {
+            case KEYMOD_SHIFT:
+                modifier = 2;
+                break;
+            case KEYMOD_ALT:
+                modifier = 3;
+                break;
+            case (KEYMOD_SHIFT | KEYMOD_ALT):
+                modifier = 4;
+                break;
+            case KEYMOD_CTRL:
+                modifier = 5;
+                break;
+            case KEYMOD_SHIFT | KEYMOD_CTRL:
+                modifier = 6;
+                break;
+            case KEYMOD_ALT | KEYMOD_CTRL:
+                modifier = 7;
+                break;
+            case KEYMOD_SHIFT | KEYMOD_ALT | KEYMOD_CTRL:
+                modifier = 8;
+                break;
+            default:
+                return start + lastChar;
+        }
+        return start + (";" + modifier) + lastChar;
+    }
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/Logger.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/Logger.java
@@ -1,0 +1,80 @@
+package com.termux.terminal;
+
+import android.util.Log;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class Logger {
+
+    public static void logError(TerminalSessionClient client, String logTag, String message) {
+        if (client != null)
+            client.logError(logTag, message);
+        else
+            Log.e(logTag, message);
+    }
+
+    public static void logWarn(TerminalSessionClient client, String logTag, String message) {
+        if (client != null)
+            client.logWarn(logTag, message);
+        else
+            Log.w(logTag, message);
+    }
+
+    public static void logInfo(TerminalSessionClient client, String logTag, String message) {
+        if (client != null)
+            client.logInfo(logTag, message);
+        else
+            Log.i(logTag, message);
+    }
+
+    public static void logDebug(TerminalSessionClient client, String logTag, String message) {
+        if (client != null)
+            client.logDebug(logTag, message);
+        else
+            Log.d(logTag, message);
+    }
+
+    public static void logVerbose(TerminalSessionClient client, String logTag, String message) {
+        if (client != null)
+            client.logVerbose(logTag, message);
+        else
+            Log.v(logTag, message);
+    }
+
+    public static void logStackTraceWithMessage(TerminalSessionClient client, String tag, String message, Throwable throwable) {
+        logError(client, tag, getMessageAndStackTraceString(message, throwable));
+    }
+
+    public static String getMessageAndStackTraceString(String message, Throwable throwable) {
+        if (message == null && throwable == null)
+            return null;
+        else if (message != null && throwable != null)
+            return message + ":\n" + getStackTraceString(throwable);
+        else if (throwable == null)
+            return message;
+        else
+            return getStackTraceString(throwable);
+    }
+
+    public static String getStackTraceString(Throwable throwable) {
+        if (throwable == null) return null;
+
+        String stackTraceString = null;
+
+        try {
+            StringWriter errors = new StringWriter();
+            PrintWriter pw = new PrintWriter(errors);
+            throwable.printStackTrace(pw);
+            pw.close();
+            stackTraceString = errors.toString();
+            errors.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return stackTraceString;
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -1,0 +1,497 @@
+package com.termux.terminal;
+
+import java.util.Arrays;
+
+/**
+ * A circular buffer of {@link TerminalRow}:s which keeps notes about what is visible on a logical screen and the scroll
+ * history.
+ * <p>
+ * See {@link #externalToInternalRow(int)} for how to map from logical screen rows to array indices.
+ */
+public final class TerminalBuffer {
+
+    TerminalRow[] mLines;
+    /** The length of {@link #mLines}. */
+    int mTotalRows;
+    /** The number of rows and columns visible on the screen. */
+    int mScreenRows, mColumns;
+    /** The number of rows kept in history. */
+    private int mActiveTranscriptRows = 0;
+    /** The index in the circular buffer where the visible screen starts. */
+    private int mScreenFirstRow = 0;
+
+    /**
+     * Create a transcript screen.
+     *
+     * @param columns    the width of the screen in characters.
+     * @param totalRows  the height of the entire text area, in rows of text.
+     * @param screenRows the height of just the screen, not including the transcript that holds lines that have scrolled off
+     *                   the top of the screen.
+     */
+    public TerminalBuffer(int columns, int totalRows, int screenRows) {
+        mColumns = columns;
+        mTotalRows = totalRows;
+        mScreenRows = screenRows;
+        mLines = new TerminalRow[totalRows];
+
+        blockSet(0, 0, columns, screenRows, ' ', TextStyle.NORMAL);
+    }
+
+    public String getTranscriptText() {
+        return getSelectedText(0, -getActiveTranscriptRows(), mColumns, mScreenRows).trim();
+    }
+
+    public String getTranscriptTextWithoutJoinedLines() {
+        return getSelectedText(0, -getActiveTranscriptRows(), mColumns, mScreenRows, false).trim();
+    }
+
+    public String getTranscriptTextWithFullLinesJoined() {
+        return getSelectedText(0, -getActiveTranscriptRows(), mColumns, mScreenRows, true, true).trim();
+    }
+
+    public String getSelectedText(int selX1, int selY1, int selX2, int selY2) {
+        return getSelectedText(selX1, selY1, selX2, selY2, true);
+    }
+
+    public String getSelectedText(int selX1, int selY1, int selX2, int selY2, boolean joinBackLines) {
+        return getSelectedText(selX1, selY1, selX2, selY2, joinBackLines, false);
+    }
+
+    public String getSelectedText(int selX1, int selY1, int selX2, int selY2, boolean joinBackLines, boolean joinFullLines) {
+        final StringBuilder builder = new StringBuilder();
+        final int columns = mColumns;
+
+        if (selY1 < -getActiveTranscriptRows()) selY1 = -getActiveTranscriptRows();
+        if (selY2 >= mScreenRows) selY2 = mScreenRows - 1;
+
+        for (int row = selY1; row <= selY2; row++) {
+            int x1 = (row == selY1) ? selX1 : 0;
+            int x2;
+            if (row == selY2) {
+                x2 = selX2 + 1;
+                if (x2 > columns) x2 = columns;
+            } else {
+                x2 = columns;
+            }
+            TerminalRow lineObject = mLines[externalToInternalRow(row)];
+            int x1Index = lineObject.findStartOfColumn(x1);
+            int x2Index = (x2 < mColumns) ? lineObject.findStartOfColumn(x2) : lineObject.getSpaceUsed();
+            if (x2Index == x1Index) {
+                // Selected the start of a wide character.
+                x2Index = lineObject.findStartOfColumn(x2 + 1);
+            }
+            char[] line = lineObject.mText;
+            int lastPrintingCharIndex = -1;
+            int i;
+            boolean rowLineWrap = getLineWrap(row);
+            if (rowLineWrap && x2 == columns) {
+                // If the line was wrapped, we shouldn't lose trailing space:
+                lastPrintingCharIndex = x2Index - 1;
+            } else {
+                for (i = x1Index; i < x2Index; ++i) {
+                    char c = line[i];
+                    if (c != ' ') lastPrintingCharIndex = i;
+                }
+            }
+
+            int len = lastPrintingCharIndex - x1Index + 1;
+            if (lastPrintingCharIndex != -1 && len > 0)
+                builder.append(line, x1Index, len);
+
+            boolean lineFillsWidth = lastPrintingCharIndex == x2Index - 1;
+            if ((!joinBackLines || !rowLineWrap) && (!joinFullLines || !lineFillsWidth)
+                && row < selY2 && row < mScreenRows - 1) builder.append('\n');
+        }
+        return builder.toString();
+    }
+
+    public String getWordAtLocation(int x, int y) {
+        // Set y1 and y2 to the lines where the wrapped line starts and ends.
+        // I.e. if a line that is wrapped to 3 lines starts at line 4, and this
+        // is called with y=5, then y1 would be set to 4 and y2 would be set to 6.
+        int y1 = y;
+        int y2 = y;
+        while (y1 > 0 && !getSelectedText(0, y1 - 1, mColumns, y, true, true).contains("\n")) {
+            y1--;
+        }
+        while (y2 < mScreenRows && !getSelectedText(0, y, mColumns, y2 + 1, true, true).contains("\n")) {
+            y2++;
+        }
+
+        // Get the text for the whole wrapped line
+        String text = getSelectedText(0, y1, mColumns, y2, true, true);
+        // The index of x in text
+        int textOffset = (y - y1) * mColumns + x;
+
+        if (textOffset >= text.length()) {
+          // The click was to the right of the last word on the line, so
+          // there's no word to return
+          return "";
+        }
+
+        // Set x1 and x2 to the indices of the last space before x and the
+        // first space after x in text respectively
+        int x1 = text.lastIndexOf(' ', textOffset);
+        int x2 = text.indexOf(' ', textOffset);
+        if (x2 == -1) {
+            x2 = text.length();
+        }
+
+        if (x1 == x2) {
+          // The click was on a space, so there's no word to return
+          return "";
+        }
+        return text.substring(x1 + 1, x2);
+    }
+
+    public int getActiveTranscriptRows() {
+        return mActiveTranscriptRows;
+    }
+
+    public int getActiveRows() {
+        return mActiveTranscriptRows + mScreenRows;
+    }
+
+    /**
+     * Convert a row value from the public external coordinate system to our internal private coordinate system.
+     *
+     * <pre>
+     * - External coordinate system: -mActiveTranscriptRows to mScreenRows-1, with the screen being 0..mScreenRows-1.
+     * - Internal coordinate system: the mScreenRows lines starting at mScreenFirstRow comprise the screen, while the
+     *   mActiveTranscriptRows lines ending at mScreenFirstRow-1 form the transcript (as a circular buffer).
+     *
+     * External ↔ Internal:
+     *
+     * [ ...                            ]     [ ...                                     ]
+     * [ -mActiveTranscriptRows         ]     [ mScreenFirstRow - mActiveTranscriptRows ]
+     * [ ...                            ]     [ ...                                     ]
+     * [ 0 (visible screen starts here) ]  ↔  [ mScreenFirstRow                         ]
+     * [ ...                            ]     [ ...                                     ]
+     * [ mScreenRows-1                  ]     [ mScreenFirstRow + mScreenRows-1         ]
+     * </pre>
+     *
+     * @param externalRow a row in the external coordinate system.
+     * @return The row corresponding to the input argument in the private coordinate system.
+     */
+    public int externalToInternalRow(int externalRow) {
+        if (externalRow < -mActiveTranscriptRows || externalRow > mScreenRows)
+            throw new IllegalArgumentException("extRow=" + externalRow + ", mScreenRows=" + mScreenRows + ", mActiveTranscriptRows=" + mActiveTranscriptRows);
+        final int internalRow = mScreenFirstRow + externalRow;
+        return (internalRow < 0) ? (mTotalRows + internalRow) : (internalRow % mTotalRows);
+    }
+
+    public void setLineWrap(int row) {
+        mLines[externalToInternalRow(row)].mLineWrap = true;
+    }
+
+    public boolean getLineWrap(int row) {
+        return mLines[externalToInternalRow(row)].mLineWrap;
+    }
+
+    public void clearLineWrap(int row) {
+        mLines[externalToInternalRow(row)].mLineWrap = false;
+    }
+
+    /**
+     * Resize the screen which this transcript backs. Currently, this only works if the number of columns does not
+     * change or the rows expand (that is, it only works when shrinking the number of rows).
+     *
+     * @param newColumns The number of columns the screen should have.
+     * @param newRows    The number of rows the screen should have.
+     * @param cursor     An int[2] containing the (column, row) cursor location.
+     */
+    public void resize(int newColumns, int newRows, int newTotalRows, int[] cursor, long currentStyle, boolean altScreen) {
+        // newRows > mTotalRows should not normally happen since mTotalRows is TRANSCRIPT_ROWS (10000):
+        if (newColumns == mColumns && newRows <= mTotalRows) {
+            // Fast resize where just the rows changed.
+            int shiftDownOfTopRow = mScreenRows - newRows;
+            if (shiftDownOfTopRow > 0 && shiftDownOfTopRow < mScreenRows) {
+                // Shrinking. Check if we can skip blank rows at bottom below cursor.
+                for (int i = mScreenRows - 1; i > 0; i--) {
+                    if (cursor[1] >= i) break;
+                    int r = externalToInternalRow(i);
+                    if (mLines[r] == null || mLines[r].isBlank()) {
+                        if (--shiftDownOfTopRow == 0) break;
+                    }
+                }
+            } else if (shiftDownOfTopRow < 0) {
+                // Negative shift down = expanding. Only move screen up if there is transcript to show:
+                int actualShift = Math.max(shiftDownOfTopRow, -mActiveTranscriptRows);
+                if (shiftDownOfTopRow != actualShift) {
+                    // The new lines revealed by the resizing are not all from the transcript. Blank the below ones.
+                    for (int i = 0; i < actualShift - shiftDownOfTopRow; i++)
+                        allocateFullLineIfNecessary((mScreenFirstRow + mScreenRows + i) % mTotalRows).clear(currentStyle);
+                    shiftDownOfTopRow = actualShift;
+                }
+            }
+            mScreenFirstRow += shiftDownOfTopRow;
+            mScreenFirstRow = (mScreenFirstRow < 0) ? (mScreenFirstRow + mTotalRows) : (mScreenFirstRow % mTotalRows);
+            mTotalRows = newTotalRows;
+            mActiveTranscriptRows = altScreen ? 0 : Math.max(0, mActiveTranscriptRows + shiftDownOfTopRow);
+            cursor[1] -= shiftDownOfTopRow;
+            mScreenRows = newRows;
+        } else {
+            // Copy away old state and update new:
+            TerminalRow[] oldLines = mLines;
+            mLines = new TerminalRow[newTotalRows];
+            for (int i = 0; i < newTotalRows; i++)
+                mLines[i] = new TerminalRow(newColumns, currentStyle);
+
+            final int oldActiveTranscriptRows = mActiveTranscriptRows;
+            final int oldScreenFirstRow = mScreenFirstRow;
+            final int oldScreenRows = mScreenRows;
+            final int oldTotalRows = mTotalRows;
+            mTotalRows = newTotalRows;
+            mScreenRows = newRows;
+            mActiveTranscriptRows = mScreenFirstRow = 0;
+            mColumns = newColumns;
+
+            int newCursorRow = -1;
+            int newCursorColumn = -1;
+            int oldCursorRow = cursor[1];
+            int oldCursorColumn = cursor[0];
+            boolean newCursorPlaced = false;
+
+            int currentOutputExternalRow = 0;
+            int currentOutputExternalColumn = 0;
+
+            // Loop over every character in the initial state.
+            // Blank lines should be skipped only if at end of transcript (just as is done in the "fast" resize), so we
+            // keep track how many blank lines we have skipped if we later on find a non-blank line.
+            int skippedBlankLines = 0;
+            for (int externalOldRow = -oldActiveTranscriptRows; externalOldRow < oldScreenRows; externalOldRow++) {
+                // Do what externalToInternalRow() does but for the old state:
+                int internalOldRow = oldScreenFirstRow + externalOldRow;
+                internalOldRow = (internalOldRow < 0) ? (oldTotalRows + internalOldRow) : (internalOldRow % oldTotalRows);
+
+                TerminalRow oldLine = oldLines[internalOldRow];
+                boolean cursorAtThisRow = externalOldRow == oldCursorRow;
+                // The cursor may only be on a non-null line, which we should not skip:
+                if (oldLine == null || (!(!newCursorPlaced && cursorAtThisRow)) && oldLine.isBlank()) {
+                    skippedBlankLines++;
+                    continue;
+                } else if (skippedBlankLines > 0) {
+                    // After skipping some blank lines we encounter a non-blank line. Insert the skipped blank lines.
+                    for (int i = 0; i < skippedBlankLines; i++) {
+                        if (currentOutputExternalRow == mScreenRows - 1) {
+                            scrollDownOneLine(0, mScreenRows, currentStyle);
+                        } else {
+                            currentOutputExternalRow++;
+                        }
+                        currentOutputExternalColumn = 0;
+                    }
+                    skippedBlankLines = 0;
+                }
+
+                int lastNonSpaceIndex = 0;
+                boolean justToCursor = false;
+                if (cursorAtThisRow || oldLine.mLineWrap) {
+                    // Take the whole line, either because of cursor on it, or if line wrapping.
+                    lastNonSpaceIndex = oldLine.getSpaceUsed();
+                    if (cursorAtThisRow) justToCursor = true;
+                } else {
+                    for (int i = 0; i < oldLine.getSpaceUsed(); i++)
+                        // NEWLY INTRODUCED BUG! Should not index oldLine.mStyle with char indices
+                        if (oldLine.mText[i] != ' '/* || oldLine.mStyle[i] != currentStyle */)
+                            lastNonSpaceIndex = i + 1;
+                }
+
+                int currentOldCol = 0;
+                long styleAtCol = 0;
+                for (int i = 0; i < lastNonSpaceIndex; i++) {
+                    // Note that looping over java character, not cells.
+                    char c = oldLine.mText[i];
+                    int codePoint = (Character.isHighSurrogate(c)) ? Character.toCodePoint(c, oldLine.mText[++i]) : c;
+                    int displayWidth = WcWidth.width(codePoint);
+                    // Use the last style if this is a zero-width character:
+                    if (displayWidth > 0) styleAtCol = oldLine.getStyle(currentOldCol);
+
+                    // Line wrap as necessary:
+                    if (currentOutputExternalColumn + displayWidth > mColumns) {
+                        setLineWrap(currentOutputExternalRow);
+                        if (currentOutputExternalRow == mScreenRows - 1) {
+                            if (newCursorPlaced) newCursorRow--;
+                            scrollDownOneLine(0, mScreenRows, currentStyle);
+                        } else {
+                            currentOutputExternalRow++;
+                        }
+                        currentOutputExternalColumn = 0;
+                    }
+
+                    int offsetDueToCombiningChar = ((displayWidth <= 0 && currentOutputExternalColumn > 0) ? 1 : 0);
+                    int outputColumn = currentOutputExternalColumn - offsetDueToCombiningChar;
+                    setChar(outputColumn, currentOutputExternalRow, codePoint, styleAtCol);
+
+                    if (displayWidth > 0) {
+                        if (oldCursorRow == externalOldRow && oldCursorColumn == currentOldCol) {
+                            newCursorColumn = currentOutputExternalColumn;
+                            newCursorRow = currentOutputExternalRow;
+                            newCursorPlaced = true;
+                        }
+                        currentOldCol += displayWidth;
+                        currentOutputExternalColumn += displayWidth;
+                        if (justToCursor && newCursorPlaced) break;
+                    }
+                }
+                // Old row has been copied. Check if we need to insert newline if old line was not wrapping:
+                if (externalOldRow != (oldScreenRows - 1) && !oldLine.mLineWrap) {
+                    if (currentOutputExternalRow == mScreenRows - 1) {
+                        if (newCursorPlaced) newCursorRow--;
+                        scrollDownOneLine(0, mScreenRows, currentStyle);
+                    } else {
+                        currentOutputExternalRow++;
+                    }
+                    currentOutputExternalColumn = 0;
+                }
+            }
+
+            cursor[0] = newCursorColumn;
+            cursor[1] = newCursorRow;
+        }
+
+        // Handle cursor scrolling off screen:
+        if (cursor[0] < 0 || cursor[1] < 0) cursor[0] = cursor[1] = 0;
+    }
+
+    /**
+     * Block copy lines and associated metadata from one location to another in the circular buffer, taking wraparound
+     * into account.
+     *
+     * @param srcInternal The first line to be copied.
+     * @param len         The number of lines to be copied.
+     */
+    private void blockCopyLinesDown(int srcInternal, int len) {
+        if (len == 0) return;
+        int totalRows = mTotalRows;
+
+        int start = len - 1;
+        // Save away line to be overwritten:
+        TerminalRow lineToBeOverWritten = mLines[(srcInternal + start + 1) % totalRows];
+        // Do the copy from bottom to top.
+        for (int i = start; i >= 0; --i)
+            mLines[(srcInternal + i + 1) % totalRows] = mLines[(srcInternal + i) % totalRows];
+        // Put back overwritten line, now above the block:
+        mLines[(srcInternal) % totalRows] = lineToBeOverWritten;
+    }
+
+    /**
+     * Scroll the screen down one line. To scroll the whole screen of a 24 line screen, the arguments would be (0, 24).
+     *
+     * @param topMargin    First line that is scrolled.
+     * @param bottomMargin One line after the last line that is scrolled.
+     * @param style        the style for the newly exposed line.
+     */
+    public void scrollDownOneLine(int topMargin, int bottomMargin, long style) {
+        if (topMargin > bottomMargin - 1 || topMargin < 0 || bottomMargin > mScreenRows)
+            throw new IllegalArgumentException("topMargin=" + topMargin + ", bottomMargin=" + bottomMargin + ", mScreenRows=" + mScreenRows);
+
+        // Copy the fixed topMargin lines one line down so that they remain on screen in same position:
+        blockCopyLinesDown(mScreenFirstRow, topMargin);
+        // Copy the fixed mScreenRows-bottomMargin lines one line down so that they remain on screen in same
+        // position:
+        blockCopyLinesDown(externalToInternalRow(bottomMargin), mScreenRows - bottomMargin);
+
+        // Update the screen location in the ring buffer:
+        mScreenFirstRow = (mScreenFirstRow + 1) % mTotalRows;
+        // Note that the history has grown if not already full:
+        if (mActiveTranscriptRows < mTotalRows - mScreenRows) mActiveTranscriptRows++;
+
+        // Blank the newly revealed line above the bottom margin:
+        int blankRow = externalToInternalRow(bottomMargin - 1);
+        if (mLines[blankRow] == null) {
+            mLines[blankRow] = new TerminalRow(mColumns, style);
+        } else {
+            mLines[blankRow].clear(style);
+        }
+    }
+
+    /**
+     * Block copy characters from one position in the screen to another. The two positions can overlap. All characters
+     * of the source and destination must be within the bounds of the screen, or else an InvalidParameterException will
+     * be thrown.
+     *
+     * @param sx source X coordinate
+     * @param sy source Y coordinate
+     * @param w  width
+     * @param h  height
+     * @param dx destination X coordinate
+     * @param dy destination Y coordinate
+     */
+    public void blockCopy(int sx, int sy, int w, int h, int dx, int dy) {
+        if (w == 0) return;
+        if (sx < 0 || sx + w > mColumns || sy < 0 || sy + h > mScreenRows || dx < 0 || dx + w > mColumns || dy < 0 || dy + h > mScreenRows)
+            throw new IllegalArgumentException();
+        boolean copyingUp = sy > dy;
+        for (int y = 0; y < h; y++) {
+            int y2 = copyingUp ? y : (h - (y + 1));
+            TerminalRow sourceRow = allocateFullLineIfNecessary(externalToInternalRow(sy + y2));
+            allocateFullLineIfNecessary(externalToInternalRow(dy + y2)).copyInterval(sourceRow, sx, sx + w, dx);
+        }
+    }
+
+    /**
+     * Block set characters. All characters must be within the bounds of the screen, or else and
+     * InvalidParemeterException will be thrown. Typically this is called with a "val" argument of 32 to clear a block
+     * of characters.
+     */
+    public void blockSet(int sx, int sy, int w, int h, int val, long style) {
+        if (sx < 0 || sx + w > mColumns || sy < 0 || sy + h > mScreenRows) {
+            throw new IllegalArgumentException(
+                "Illegal arguments! blockSet(" + sx + ", " + sy + ", " + w + ", " + h + ", " + val + ", " + mColumns + ", " + mScreenRows + ")");
+        }
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+                setChar(sx + x, sy + y, val, style);
+    }
+
+    public TerminalRow allocateFullLineIfNecessary(int row) {
+        return (mLines[row] == null) ? (mLines[row] = new TerminalRow(mColumns, 0)) : mLines[row];
+    }
+
+    public void setChar(int column, int row, int codePoint, long style) {
+        if (row  < 0 || row >= mScreenRows || column < 0 || column >= mColumns)
+            throw new IllegalArgumentException("TerminalBuffer.setChar(): row=" + row + ", column=" + column + ", mScreenRows=" + mScreenRows + ", mColumns=" + mColumns);
+        row = externalToInternalRow(row);
+        allocateFullLineIfNecessary(row).setChar(column, codePoint, style);
+    }
+
+    public long getStyleAt(int externalRow, int column) {
+        return allocateFullLineIfNecessary(externalToInternalRow(externalRow)).getStyle(column);
+    }
+
+    /** Support for http://vt100.net/docs/vt510-rm/DECCARA and http://vt100.net/docs/vt510-rm/DECCARA */
+    public void setOrClearEffect(int bits, boolean setOrClear, boolean reverse, boolean rectangular, int leftMargin, int rightMargin, int top, int left,
+                                 int bottom, int right) {
+        for (int y = top; y < bottom; y++) {
+            TerminalRow line = mLines[externalToInternalRow(y)];
+            int startOfLine = (rectangular || y == top) ? left : leftMargin;
+            int endOfLine = (rectangular || y + 1 == bottom) ? right : rightMargin;
+            for (int x = startOfLine; x < endOfLine; x++) {
+                long currentStyle = line.getStyle(x);
+                int foreColor = TextStyle.decodeForeColor(currentStyle);
+                int backColor = TextStyle.decodeBackColor(currentStyle);
+                int effect = TextStyle.decodeEffect(currentStyle);
+                if (reverse) {
+                    // Clear out the bits to reverse and add them back in reversed:
+                    effect = (effect & ~bits) | (bits & ~effect);
+                } else if (setOrClear) {
+                    effect |= bits;
+                } else {
+                    effect &= ~bits;
+                }
+                line.mStyle[x] = TextStyle.encode(foreColor, backColor, effect);
+            }
+        }
+    }
+
+    public void clearTranscript() {
+        if (mScreenFirstRow < mActiveTranscriptRows) {
+            Arrays.fill(mLines, mTotalRows + mScreenFirstRow - mActiveTranscriptRows, mTotalRows, null);
+            Arrays.fill(mLines, 0, mScreenFirstRow, null);
+        } else {
+            Arrays.fill(mLines, mScreenFirstRow - mActiveTranscriptRows, mScreenFirstRow, null);
+        }
+        mActiveTranscriptRows = 0;
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColorScheme.java
@@ -1,0 +1,126 @@
+package com.termux.terminal;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Color scheme for a terminal with default colors, which may be overridden (and then reset) from the shell using
+ * Operating System Control (OSC) sequences.
+ *
+ * @see TerminalColors
+ */
+public final class TerminalColorScheme {
+
+    /** http://upload.wikimedia.org/wikipedia/en/1/15/Xterm_256color_chart.svg, but with blue color brighter. */
+    private static final int[] DEFAULT_COLORSCHEME = {
+        // 16 original colors. First 8 are dim.
+        0xff000000, // black
+        0xffcd0000, // dim red
+        0xff00cd00, // dim green
+        0xffcdcd00, // dim yellow
+        0xff6495ed, // dim blue
+        0xffcd00cd, // dim magenta
+        0xff00cdcd, // dim cyan
+        0xffe5e5e5, // dim white
+        // Second 8 are bright:
+        0xff7f7f7f, // medium grey
+        0xffff0000, // bright red
+        0xff00ff00, // bright green
+        0xffffff00, // bright yellow
+        0xff5c5cff, // light blue
+        0xffff00ff, // bright magenta
+        0xff00ffff, // bright cyan
+        0xffffffff, // bright white
+
+        // 216 color cube, six shades of each color:
+        0xff000000, 0xff00005f, 0xff000087, 0xff0000af, 0xff0000d7, 0xff0000ff, 0xff005f00, 0xff005f5f, 0xff005f87, 0xff005faf, 0xff005fd7, 0xff005fff,
+        0xff008700, 0xff00875f, 0xff008787, 0xff0087af, 0xff0087d7, 0xff0087ff, 0xff00af00, 0xff00af5f, 0xff00af87, 0xff00afaf, 0xff00afd7, 0xff00afff,
+        0xff00d700, 0xff00d75f, 0xff00d787, 0xff00d7af, 0xff00d7d7, 0xff00d7ff, 0xff00ff00, 0xff00ff5f, 0xff00ff87, 0xff00ffaf, 0xff00ffd7, 0xff00ffff,
+        0xff5f0000, 0xff5f005f, 0xff5f0087, 0xff5f00af, 0xff5f00d7, 0xff5f00ff, 0xff5f5f00, 0xff5f5f5f, 0xff5f5f87, 0xff5f5faf, 0xff5f5fd7, 0xff5f5fff,
+        0xff5f8700, 0xff5f875f, 0xff5f8787, 0xff5f87af, 0xff5f87d7, 0xff5f87ff, 0xff5faf00, 0xff5faf5f, 0xff5faf87, 0xff5fafaf, 0xff5fafd7, 0xff5fafff,
+        0xff5fd700, 0xff5fd75f, 0xff5fd787, 0xff5fd7af, 0xff5fd7d7, 0xff5fd7ff, 0xff5fff00, 0xff5fff5f, 0xff5fff87, 0xff5fffaf, 0xff5fffd7, 0xff5fffff,
+        0xff870000, 0xff87005f, 0xff870087, 0xff8700af, 0xff8700d7, 0xff8700ff, 0xff875f00, 0xff875f5f, 0xff875f87, 0xff875faf, 0xff875fd7, 0xff875fff,
+        0xff878700, 0xff87875f, 0xff878787, 0xff8787af, 0xff8787d7, 0xff8787ff, 0xff87af00, 0xff87af5f, 0xff87af87, 0xff87afaf, 0xff87afd7, 0xff87afff,
+        0xff87d700, 0xff87d75f, 0xff87d787, 0xff87d7af, 0xff87d7d7, 0xff87d7ff, 0xff87ff00, 0xff87ff5f, 0xff87ff87, 0xff87ffaf, 0xff87ffd7, 0xff87ffff,
+        0xffaf0000, 0xffaf005f, 0xffaf0087, 0xffaf00af, 0xffaf00d7, 0xffaf00ff, 0xffaf5f00, 0xffaf5f5f, 0xffaf5f87, 0xffaf5faf, 0xffaf5fd7, 0xffaf5fff,
+        0xffaf8700, 0xffaf875f, 0xffaf8787, 0xffaf87af, 0xffaf87d7, 0xffaf87ff, 0xffafaf00, 0xffafaf5f, 0xffafaf87, 0xffafafaf, 0xffafafd7, 0xffafafff,
+        0xffafd700, 0xffafd75f, 0xffafd787, 0xffafd7af, 0xffafd7d7, 0xffafd7ff, 0xffafff00, 0xffafff5f, 0xffafff87, 0xffafffaf, 0xffafffd7, 0xffafffff,
+        0xffd70000, 0xffd7005f, 0xffd70087, 0xffd700af, 0xffd700d7, 0xffd700ff, 0xffd75f00, 0xffd75f5f, 0xffd75f87, 0xffd75faf, 0xffd75fd7, 0xffd75fff,
+        0xffd78700, 0xffd7875f, 0xffd78787, 0xffd787af, 0xffd787d7, 0xffd787ff, 0xffd7af00, 0xffd7af5f, 0xffd7af87, 0xffd7afaf, 0xffd7afd7, 0xffd7afff,
+        0xffd7d700, 0xffd7d75f, 0xffd7d787, 0xffd7d7af, 0xffd7d7d7, 0xffd7d7ff, 0xffd7ff00, 0xffd7ff5f, 0xffd7ff87, 0xffd7ffaf, 0xffd7ffd7, 0xffd7ffff,
+        0xffff0000, 0xffff005f, 0xffff0087, 0xffff00af, 0xffff00d7, 0xffff00ff, 0xffff5f00, 0xffff5f5f, 0xffff5f87, 0xffff5faf, 0xffff5fd7, 0xffff5fff,
+        0xffff8700, 0xffff875f, 0xffff8787, 0xffff87af, 0xffff87d7, 0xffff87ff, 0xffffaf00, 0xffffaf5f, 0xffffaf87, 0xffffafaf, 0xffffafd7, 0xffffafff,
+        0xffffd700, 0xffffd75f, 0xffffd787, 0xffffd7af, 0xffffd7d7, 0xffffd7ff, 0xffffff00, 0xffffff5f, 0xffffff87, 0xffffffaf, 0xffffffd7, 0xffffffff,
+
+        // 24 grey scale ramp:
+        0xff080808, 0xff121212, 0xff1c1c1c, 0xff262626, 0xff303030, 0xff3a3a3a, 0xff444444, 0xff4e4e4e, 0xff585858, 0xff626262, 0xff6c6c6c, 0xff767676,
+        0xff808080, 0xff8a8a8a, 0xff949494, 0xff9e9e9e, 0xffa8a8a8, 0xffb2b2b2, 0xffbcbcbc, 0xffc6c6c6, 0xffd0d0d0, 0xffdadada, 0xffe4e4e4, 0xffeeeeee,
+
+        // COLOR_INDEX_DEFAULT_FOREGROUND, COLOR_INDEX_DEFAULT_BACKGROUND and COLOR_INDEX_DEFAULT_CURSOR:
+        0xffffffff, 0xff000000, 0xffffffff};
+
+    public final int[] mDefaultColors = new int[TextStyle.NUM_INDEXED_COLORS];
+
+    public TerminalColorScheme() {
+        reset();
+    }
+
+    private void reset() {
+        System.arraycopy(DEFAULT_COLORSCHEME, 0, mDefaultColors, 0, TextStyle.NUM_INDEXED_COLORS);
+    }
+
+    public void updateWith(Properties props) {
+        reset();
+        boolean cursorPropExists = false;
+        for (Map.Entry<Object, Object> entries : props.entrySet()) {
+            String key = (String) entries.getKey();
+            String value = (String) entries.getValue();
+            int colorIndex;
+
+            if (key.equals("foreground")) {
+                colorIndex = TextStyle.COLOR_INDEX_FOREGROUND;
+            } else if (key.equals("background")) {
+                colorIndex = TextStyle.COLOR_INDEX_BACKGROUND;
+            } else if (key.equals("cursor")) {
+                colorIndex = TextStyle.COLOR_INDEX_CURSOR;
+                cursorPropExists = true;
+            } else if (key.startsWith("color")) {
+                try {
+                    colorIndex = Integer.parseInt(key.substring(5));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Invalid property: '" + key + "'");
+                }
+            } else {
+                throw new IllegalArgumentException("Invalid property: '" + key + "'");
+            }
+
+            int colorValue = TerminalColors.parse(value);
+            if (colorValue == 0)
+                throw new IllegalArgumentException("Property '" + key + "' has invalid color: '" + value + "'");
+
+            mDefaultColors[colorIndex] = colorValue;
+        }
+
+        if (!cursorPropExists)
+            setCursorColorForBackground();
+    }
+
+    /**
+     * If the "cursor" color is not set by user, we need to decide on the appropriate color that will
+     * be visible on the current terminal background. White will not be visible on light backgrounds
+     * and black won't be visible on dark backgrounds. So we find the perceived brightness of the
+     * background color and if its below the threshold (too dark), we use white cursor and if its
+     * above (too bright), we use black cursor.
+     */
+    public void setCursorColorForBackground() {
+        int backgroundColor = mDefaultColors[TextStyle.COLOR_INDEX_BACKGROUND];
+        int brightness = TerminalColors.getPerceivedBrightnessOfColor(backgroundColor);
+        if (brightness > 0) {
+            if (brightness < 130)
+                mDefaultColors[TextStyle.COLOR_INDEX_CURSOR] = 0xffffffff;
+            else
+                mDefaultColors[TextStyle.COLOR_INDEX_CURSOR] = 0xff000000;
+        }
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalColors.java
@@ -1,0 +1,96 @@
+package com.termux.terminal;
+
+import android.graphics.Color;
+
+/** Current terminal colors (if different from default). */
+public final class TerminalColors {
+
+    /** Static data - a bit ugly but ok for now. */
+    public static final TerminalColorScheme COLOR_SCHEME = new TerminalColorScheme();
+
+    /**
+     * The current terminal colors, which are normally set from the color theme, but may be set dynamically with the OSC
+     * 4 control sequence.
+     */
+    public final int[] mCurrentColors = new int[TextStyle.NUM_INDEXED_COLORS];
+
+    /** Create a new instance with default colors from the theme. */
+    public TerminalColors() {
+        reset();
+    }
+
+    /** Reset a particular indexed color with the default color from the color theme. */
+    public void reset(int index) {
+        mCurrentColors[index] = COLOR_SCHEME.mDefaultColors[index];
+    }
+
+    /** Reset all indexed colors with the default color from the color theme. */
+    public void reset() {
+        System.arraycopy(COLOR_SCHEME.mDefaultColors, 0, mCurrentColors, 0, TextStyle.NUM_INDEXED_COLORS);
+    }
+
+    /**
+     * Parse color according to http://manpages.ubuntu.com/manpages/intrepid/man3/XQueryColor.3.html
+     * <p/>
+     * Highest bit is set if successful, so return value is 0xFF${R}${G}${B}. Return 0 if failed.
+     */
+    static int parse(String c) {
+        try {
+            int skipInitial, skipBetween;
+            if (c.charAt(0) == '#') {
+                // #RGB, #RRGGBB, #RRRGGGBBB or #RRRRGGGGBBBB. Most significant bits.
+                skipInitial = 1;
+                skipBetween = 0;
+            } else if (c.startsWith("rgb:")) {
+                // rgb:<red>/<green>/<blue> where <red>, <green>, <blue> := h | hh | hhh | hhhh. Scaled.
+                skipInitial = 4;
+                skipBetween = 1;
+            } else {
+                return 0;
+            }
+            int charsForColors = c.length() - skipInitial - 2 * skipBetween;
+            if (charsForColors % 3 != 0) return 0; // Unequal lengths.
+            int componentLength = charsForColors / 3;
+            double mult = 255 / (Math.pow(2, componentLength * 4) - 1);
+
+            int currentPosition = skipInitial;
+            String rString = c.substring(currentPosition, currentPosition + componentLength);
+            currentPosition += componentLength + skipBetween;
+            String gString = c.substring(currentPosition, currentPosition + componentLength);
+            currentPosition += componentLength + skipBetween;
+            String bString = c.substring(currentPosition, currentPosition + componentLength);
+
+            int r = (int) (Integer.parseInt(rString, 16) * mult);
+            int g = (int) (Integer.parseInt(gString, 16) * mult);
+            int b = (int) (Integer.parseInt(bString, 16) * mult);
+            return 0xFF << 24 | r << 16 | g << 8 | b;
+        } catch (NumberFormatException | IndexOutOfBoundsException e) {
+            return 0;
+        }
+    }
+
+    /** Try parse a color from a text parameter and into a specified index. */
+    public void tryParseColor(int intoIndex, String textParameter) {
+        int c = parse(textParameter);
+        if (c != 0) mCurrentColors[intoIndex] = c;
+    }
+
+    /**
+     * Get the perceived brightness of the color based on its RGB components.
+     *
+     * https://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
+     * http://alienryderflex.com/hsp.html
+     *
+     * @param color The color code int.
+     * @return Returns value between 0-255.
+     */
+    public static int getPerceivedBrightnessOfColor(int color) {
+        return (int)
+            Math.floor(Math.sqrt(
+                Math.pow(Color.red(color), 2) * 0.241 +
+                    Math.pow(Color.green(color), 2) * 0.691 +
+                    Math.pow(Color.blue(color), 2) * 0.068
+            ));
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -1,0 +1,2617 @@
+package com.termux.terminal;
+
+import android.util.Base64;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Stack;
+
+/**
+ * Renders text into a screen. Contains all the terminal-specific knowledge and state. Emulates a subset of the X Window
+ * System xterm terminal, which in turn is an emulator for a subset of the Digital Equipment Corporation vt100 terminal.
+ * <p>
+ * References:
+ * <ul>
+ * <li>http://invisible-island.net/xterm/ctlseqs/ctlseqs.html</li>
+ * <li>http://en.wikipedia.org/wiki/ANSI_escape_code</li>
+ * <li>http://man.he.net/man4/console_codes</li>
+ * <li>http://bazaar.launchpad.net/~leonerd/libvterm/trunk/view/head:/src/state.c</li>
+ * <li>http://www.columbia.edu/~kermit/k95manual/iso2022.html</li>
+ * <li>http://www.vt100.net/docs/vt510-rm/chapter4</li>
+ * <li>http://en.wikipedia.org/wiki/ISO/IEC_2022 - for 7-bit and 8-bit GL GR explanation</li>
+ * <li>http://bjh21.me.uk/all-escapes/all-escapes.txt - extensive!</li>
+ * <li>http://woldlab.caltech.edu/~diane/kde4.10/workingdir/kubuntu/konsole/doc/developer/old-documents/VT100/techref.
+ * html - document for konsole - accessible!</li>
+ * </ul>
+ */
+public final class TerminalEmulator {
+
+    /** Log unknown or unimplemented escape sequences received from the shell process. */
+    private static final boolean LOG_ESCAPE_SEQUENCES = false;
+
+    public static final int MOUSE_LEFT_BUTTON = 0;
+
+    /** Mouse moving while having left mouse button pressed. */
+    public static final int MOUSE_LEFT_BUTTON_MOVED = 32;
+    public static final int MOUSE_WHEELUP_BUTTON = 64;
+    public static final int MOUSE_WHEELDOWN_BUTTON = 65;
+
+    /** Used for invalid data - http://en.wikipedia.org/wiki/Replacement_character#Replacement_character */
+    public static final int UNICODE_REPLACEMENT_CHAR = 0xFFFD;
+
+    /** Escape processing: Not currently in an escape sequence. */
+    private static final int ESC_NONE = 0;
+    /** Escape processing: Have seen an ESC character - proceed to {@link #doEsc(int)} */
+    private static final int ESC = 1;
+    /** Escape processing: Have seen ESC POUND */
+    private static final int ESC_POUND = 2;
+    /** Escape processing: Have seen ESC and a character-set-select ( char */
+    private static final int ESC_SELECT_LEFT_PAREN = 3;
+    /** Escape processing: Have seen ESC and a character-set-select ) char */
+    private static final int ESC_SELECT_RIGHT_PAREN = 4;
+    /** Escape processing: "ESC [" or CSI (Control Sequence Introducer). */
+    private static final int ESC_CSI = 6;
+    /** Escape processing: ESC [ ? */
+    private static final int ESC_CSI_QUESTIONMARK = 7;
+    /** Escape processing: ESC [ $ */
+    private static final int ESC_CSI_DOLLAR = 8;
+    /** Escape processing: ESC % */
+    private static final int ESC_PERCENT = 9;
+    /** Escape processing: ESC ] (AKA OSC - Operating System Controls) */
+    private static final int ESC_OSC = 10;
+    /** Escape processing: ESC ] (AKA OSC - Operating System Controls) ESC */
+    private static final int ESC_OSC_ESC = 11;
+    /** Escape processing: ESC [ > */
+    private static final int ESC_CSI_BIGGERTHAN = 12;
+    /** Escape procession: "ESC P" or Device Control String (DCS) */
+    private static final int ESC_P = 13;
+    /** Escape processing: CSI > */
+    private static final int ESC_CSI_QUESTIONMARK_ARG_DOLLAR = 14;
+    /** Escape processing: CSI $ARGS ' ' */
+    private static final int ESC_CSI_ARGS_SPACE = 15;
+    /** Escape processing: CSI $ARGS '*' */
+    private static final int ESC_CSI_ARGS_ASTERIX = 16;
+    /** Escape processing: CSI " */
+    private static final int ESC_CSI_DOUBLE_QUOTE = 17;
+    /** Escape processing: CSI ' */
+    private static final int ESC_CSI_SINGLE_QUOTE = 18;
+    /** Escape processing: CSI ! */
+    private static final int ESC_CSI_EXCLAMATION = 19;
+    /** Escape processing: "ESC _" or Application Program Command (APC). */
+    private static final int ESC_APC = 20;
+    /** Escape processing: "ESC _" or Application Program Command (APC), followed by Escape. */
+    private static final int ESC_APC_ESCAPE = 21;
+    /** Escape processing: ESC [ <parameter bytes> */
+    private static final int ESC_CSI_UNSUPPORTED_PARAMETER_BYTE = 22;
+    /** Escape processing: ESC [ <parameter bytes> <intermediate bytes> */
+    private static final int ESC_CSI_UNSUPPORTED_INTERMEDIATE_BYTE = 23;
+
+    /** The number of parameter arguments including colon separated sub-parameters. */
+    private static final int MAX_ESCAPE_PARAMETERS = 32;
+
+    /** Needs to be large enough to contain reasonable OSC 52 pastes. */
+    private static final int MAX_OSC_STRING_LENGTH = 8192;
+
+    /** DECSET 1 - application cursor keys. */
+    private static final int DECSET_BIT_APPLICATION_CURSOR_KEYS = 1;
+    private static final int DECSET_BIT_REVERSE_VIDEO = 1 << 1;
+    /**
+     * http://www.vt100.net/docs/vt510-rm/DECOM: "When DECOM is set, the home cursor position is at the upper-left
+     * corner of the screen, within the margins. The starting point for line numbers depends on the current top margin
+     * setting. The cursor cannot move outside of the margins. When DECOM is reset, the home cursor position is at the
+     * upper-left corner of the screen. The starting point for line numbers is independent of the margins. The cursor
+     * can move outside of the margins."
+     */
+    private static final int DECSET_BIT_ORIGIN_MODE = 1 << 2;
+    /**
+     * http://www.vt100.net/docs/vt510-rm/DECAWM: "If the DECAWM function is set, then graphic characters received when
+     * the cursor is at the right border of the page appear at the beginning of the next line. Any text on the page
+     * scrolls up if the cursor is at the end of the scrolling region. If the DECAWM function is reset, then graphic
+     * characters received when the cursor is at the right border of the page replace characters already on the page."
+     */
+    private static final int DECSET_BIT_AUTOWRAP = 1 << 3;
+    /** DECSET 25 - if the cursor should be enabled, {@link #isCursorEnabled()}. */
+    private static final int DECSET_BIT_CURSOR_ENABLED = 1 << 4;
+    private static final int DECSET_BIT_APPLICATION_KEYPAD = 1 << 5;
+    /** DECSET 1000 - if to report mouse press&release events. */
+    private static final int DECSET_BIT_MOUSE_TRACKING_PRESS_RELEASE = 1 << 6;
+    /** DECSET 1002 - like 1000, but report moving mouse while pressed. */
+    private static final int DECSET_BIT_MOUSE_TRACKING_BUTTON_EVENT = 1 << 7;
+    /** DECSET 1004 - NOT implemented. */
+    private static final int DECSET_BIT_SEND_FOCUS_EVENTS = 1 << 8;
+    /** DECSET 1006 - SGR-like mouse protocol (the modern sane choice). */
+    private static final int DECSET_BIT_MOUSE_PROTOCOL_SGR = 1 << 9;
+    /** DECSET 2004 - see {@link #paste(String)} */
+    private static final int DECSET_BIT_BRACKETED_PASTE_MODE = 1 << 10;
+    /** Toggled with DECLRMM - http://www.vt100.net/docs/vt510-rm/DECLRMM */
+    private static final int DECSET_BIT_LEFTRIGHT_MARGIN_MODE = 1 << 11;
+    /** Not really DECSET bit... - http://www.vt100.net/docs/vt510-rm/DECSACE */
+    private static final int DECSET_BIT_RECTANGULAR_CHANGEATTRIBUTE = 1 << 12;
+
+
+    private String mTitle;
+    private final Stack<String> mTitleStack = new Stack<>();
+
+    /** The cursor position. Between (0,0) and (mRows-1, mColumns-1). */
+    private int mCursorRow, mCursorCol;
+
+    /** The number of character rows and columns in the terminal screen. */
+    public int mRows, mColumns;
+
+    /** Size of a terminal cell in pixels. */
+    private int mCellWidthPixels, mCellHeightPixels;
+
+    /** The number of terminal transcript rows that can be scrolled back to. */
+    public static final int TERMINAL_TRANSCRIPT_ROWS_MIN = 100;
+    public static final int TERMINAL_TRANSCRIPT_ROWS_MAX = 50000;
+    public static final int DEFAULT_TERMINAL_TRANSCRIPT_ROWS = 2000;
+
+
+    /* The supported terminal cursor styles. */
+
+    public static final int TERMINAL_CURSOR_STYLE_BLOCK = 0;
+    public static final int TERMINAL_CURSOR_STYLE_UNDERLINE = 1;
+    public static final int TERMINAL_CURSOR_STYLE_BAR = 2;
+    public static final int DEFAULT_TERMINAL_CURSOR_STYLE = TERMINAL_CURSOR_STYLE_BLOCK;
+    public static final Integer[] TERMINAL_CURSOR_STYLES_LIST = new Integer[]{TERMINAL_CURSOR_STYLE_BLOCK, TERMINAL_CURSOR_STYLE_UNDERLINE, TERMINAL_CURSOR_STYLE_BAR};
+
+    /** The terminal cursor styles. */
+    private int mCursorStyle = DEFAULT_TERMINAL_CURSOR_STYLE;
+
+
+    /** The normal screen buffer. Stores the characters that appear on the screen of the emulated terminal. */
+    private final TerminalBuffer mMainBuffer;
+    /**
+     * The alternate screen buffer, exactly as large as the display and contains no additional saved lines (so that when
+     * the alternate screen buffer is active, you cannot scroll back to view saved lines).
+     * <p>
+     * See http://www.xfree86.org/current/ctlseqs.html#The%20Alternate%20Screen%20Buffer
+     */
+    final TerminalBuffer mAltBuffer;
+    /** The current screen buffer, pointing at either {@link #mMainBuffer} or {@link #mAltBuffer}. */
+    private TerminalBuffer mScreen;
+
+    /** The terminal session this emulator is bound to. */
+    private final TerminalOutput mSession;
+
+    TerminalSessionClient mClient;
+
+    /** Keeps track of the current argument of the current escape sequence. Ranges from 0 to MAX_ESCAPE_PARAMETERS-1. */
+    private int mArgIndex;
+    /** Holds the arguments of the current escape sequence. */
+    private final int[] mArgs = new int[MAX_ESCAPE_PARAMETERS];
+    /** Holds the bit flags which arguments are sub parameters (after a colon) - bit N is set if <code>mArgs[N]</code> is a sub parameter. */
+    private int mArgsSubParamsBitSet = 0;
+
+    /** Holds OSC and device control arguments, which can be strings. */
+    private final StringBuilder mOSCOrDeviceControlArgs = new StringBuilder();
+
+    /**
+     * True if the current escape sequence should continue, false if the current escape sequence should be terminated.
+     * Used when parsing a single character.
+     */
+    private boolean mContinueSequence;
+
+    /** The current state of the escape sequence state machine. One of the ESC_* constants. */
+    private int mEscapeState;
+
+    private final SavedScreenState mSavedStateMain = new SavedScreenState();
+    private final SavedScreenState mSavedStateAlt = new SavedScreenState();
+
+    /** http://www.vt100.net/docs/vt102-ug/table5-15.html */
+    private boolean mUseLineDrawingG0, mUseLineDrawingG1, mUseLineDrawingUsesG0 = true;
+
+    /**
+     * @see TerminalEmulator#mapDecSetBitToInternalBit(int)
+     */
+    private int mCurrentDecSetFlags, mSavedDecSetFlags;
+
+    /**
+     * If insert mode (as opposed to replace mode) is active. In insert mode new characters are inserted, pushing
+     * existing text to the right. Characters moved past the right margin are lost.
+     */
+    private boolean mInsertMode;
+
+    /** An array of tab stops. mTabStop[i] is true if there is a tab stop set for column i. */
+    private boolean[] mTabStop;
+
+    /**
+     * Top margin of screen for scrolling ranges from 0 to mRows-2. Bottom margin ranges from mTopMargin + 2 to mRows
+     * (Defines the first row after the scrolling region). Left/right margin in [0, mColumns].
+     */
+    private int mTopMargin, mBottomMargin, mLeftMargin, mRightMargin;
+
+    /**
+     * If the next character to be emitted will be automatically wrapped to the next line. Used to disambiguate the case
+     * where the cursor is positioned on the last column (mColumns-1). When standing there, a written character will be
+     * output in the last column, the cursor not moving but this flag will be set. When outputting another character
+     * this will move to the next line.
+     */
+    private boolean mAboutToAutoWrap;
+
+    /**
+     * If the cursor blinking is enabled. It requires cursor itself to be enabled, which is controlled
+     * byt whether {@link #DECSET_BIT_CURSOR_ENABLED} bit is set or not.
+     */
+    private boolean mCursorBlinkingEnabled;
+
+    /**
+     * If currently cursor should be in a visible state or not if {@link #mCursorBlinkingEnabled}
+     * is {@code true}.
+     */
+    private boolean mCursorBlinkState;
+
+    /**
+     * Current foreground, background and underline colors. Can either be a color index in [0,259] or a truecolor (24-bit) value.
+     * For a 24-bit value the top byte (0xff000000) is set.
+     *
+     * <p>Note that the underline color is currently parsed but not yet used during rendering.
+     *
+     * @see TextStyle
+     */
+    int mForeColor, mBackColor, mUnderlineColor;
+
+    /** Current {@link TextStyle} effect. */
+    int mEffect;
+
+    /**
+     * The number of scrolled lines since last calling {@link #clearScrollCounter()}. Used for moving selection up along
+     * with the scrolling text.
+     */
+    private int mScrollCounter = 0;
+
+    /** If automatic scrolling of terminal is disabled */
+    private boolean mAutoScrollDisabled;
+
+    private byte mUtf8ToFollow, mUtf8Index;
+    private final byte[] mUtf8InputBuffer = new byte[4];
+    private int mLastEmittedCodePoint = -1;
+
+    public final TerminalColors mColors = new TerminalColors();
+
+    private static final String LOG_TAG = "TerminalEmulator";
+
+    private boolean isDecsetInternalBitSet(int bit) {
+        return (mCurrentDecSetFlags & bit) != 0;
+    }
+
+    private void setDecsetinternalBit(int internalBit, boolean set) {
+        if (set) {
+            // The mouse modes are mutually exclusive.
+            if (internalBit == DECSET_BIT_MOUSE_TRACKING_PRESS_RELEASE) {
+                setDecsetinternalBit(DECSET_BIT_MOUSE_TRACKING_BUTTON_EVENT, false);
+            } else if (internalBit == DECSET_BIT_MOUSE_TRACKING_BUTTON_EVENT) {
+                setDecsetinternalBit(DECSET_BIT_MOUSE_TRACKING_PRESS_RELEASE, false);
+            }
+        }
+        if (set) {
+            mCurrentDecSetFlags |= internalBit;
+        } else {
+            mCurrentDecSetFlags &= ~internalBit;
+        }
+    }
+
+    static int mapDecSetBitToInternalBit(int decsetBit) {
+        switch (decsetBit) {
+            case 1:
+                return DECSET_BIT_APPLICATION_CURSOR_KEYS;
+            case 5:
+                return DECSET_BIT_REVERSE_VIDEO;
+            case 6:
+                return DECSET_BIT_ORIGIN_MODE;
+            case 7:
+                return DECSET_BIT_AUTOWRAP;
+            case 25:
+                return DECSET_BIT_CURSOR_ENABLED;
+            case 66:
+                return DECSET_BIT_APPLICATION_KEYPAD;
+            case 69:
+                return DECSET_BIT_LEFTRIGHT_MARGIN_MODE;
+            case 1000:
+                return DECSET_BIT_MOUSE_TRACKING_PRESS_RELEASE;
+            case 1002:
+                return DECSET_BIT_MOUSE_TRACKING_BUTTON_EVENT;
+            case 1004:
+                return DECSET_BIT_SEND_FOCUS_EVENTS;
+            case 1006:
+                return DECSET_BIT_MOUSE_PROTOCOL_SGR;
+            case 2004:
+                return DECSET_BIT_BRACKETED_PASTE_MODE;
+            default:
+                return -1;
+            // throw new IllegalArgumentException("Unsupported decset: " + decsetBit);
+        }
+    }
+
+    public TerminalEmulator(TerminalOutput session, int columns, int rows, int cellWidthPixels, int cellHeightPixels, Integer transcriptRows, TerminalSessionClient client) {
+        mSession = session;
+        mScreen = mMainBuffer = new TerminalBuffer(columns, getTerminalTranscriptRows(transcriptRows), rows);
+        mAltBuffer = new TerminalBuffer(columns, rows, rows);
+        mClient = client;
+        mRows = rows;
+        mColumns = columns;
+        mCellWidthPixels = cellWidthPixels;
+        mCellHeightPixels = cellHeightPixels;
+        mTabStop = new boolean[mColumns];
+        reset();
+    }
+
+    public void updateTerminalSessionClient(TerminalSessionClient client) {
+        mClient = client;
+        setCursorStyle();
+        setCursorBlinkState(true);
+    }
+
+    public TerminalBuffer getScreen() {
+        return mScreen;
+    }
+
+    public boolean isAlternateBufferActive() {
+        return mScreen == mAltBuffer;
+    }
+
+    private int getTerminalTranscriptRows(Integer transcriptRows) {
+        if (transcriptRows == null || transcriptRows < TERMINAL_TRANSCRIPT_ROWS_MIN || transcriptRows > TERMINAL_TRANSCRIPT_ROWS_MAX)
+            return DEFAULT_TERMINAL_TRANSCRIPT_ROWS;
+        else
+            return transcriptRows;
+    }
+
+    /**
+     * @param mouseButton one of the MOUSE_* constants of this class.
+     */
+    public void sendMouseEvent(int mouseButton, int column, int row, boolean pressed) {
+        if (column < 1) column = 1;
+        if (column > mColumns) column = mColumns;
+        if (row < 1) row = 1;
+        if (row > mRows) row = mRows;
+
+        if (mouseButton == MOUSE_LEFT_BUTTON_MOVED && !isDecsetInternalBitSet(DECSET_BIT_MOUSE_TRACKING_BUTTON_EVENT)) {
+            // Do not send tracking.
+        } else if (isDecsetInternalBitSet(DECSET_BIT_MOUSE_PROTOCOL_SGR)) {
+            mSession.write(String.format("\033[<%d;%d;%d" + (pressed ? 'M' : 'm'), mouseButton, column, row));
+        } else {
+            mouseButton = pressed ? mouseButton : 3; // 3 for release of all buttons.
+            // Clip to screen, and clip to the limits of 8-bit data.
+            boolean out_of_bounds = column > 255 - 32 || row > 255 - 32;
+            if (!out_of_bounds) {
+                byte[] data = {'\033', '[', 'M', (byte) (32 + mouseButton), (byte) (32 + column), (byte) (32 + row)};
+                mSession.write(data, 0, data.length);
+            }
+        }
+    }
+
+    public void resize(int columns, int rows, int cellWidthPixels, int cellHeightPixels) {
+        this.mCellWidthPixels = cellWidthPixels;
+        this.mCellHeightPixels = cellHeightPixels;
+
+        if (mRows == rows && mColumns == columns) {
+            return;
+        } else if (columns < 2 || rows < 2) {
+            throw new IllegalArgumentException("rows=" + rows + ", columns=" + columns);
+        }
+
+        if (mRows != rows) {
+            mRows = rows;
+            mTopMargin = 0;
+            mBottomMargin = mRows;
+        }
+        if (mColumns != columns) {
+            int oldColumns = mColumns;
+            mColumns = columns;
+            boolean[] oldTabStop = mTabStop;
+            mTabStop = new boolean[mColumns];
+            setDefaultTabStops();
+            int toTransfer = Math.min(oldColumns, columns);
+            System.arraycopy(oldTabStop, 0, mTabStop, 0, toTransfer);
+            mLeftMargin = 0;
+            mRightMargin = mColumns;
+        }
+
+        resizeScreen();
+    }
+
+    private void resizeScreen() {
+        final int[] cursor = {mCursorCol, mCursorRow};
+        int newTotalRows = (mScreen == mAltBuffer) ? mRows : mMainBuffer.mTotalRows;
+        mScreen.resize(mColumns, mRows, newTotalRows, cursor, getStyle(), isAlternateBufferActive());
+        mCursorCol = cursor[0];
+        mCursorRow = cursor[1];
+    }
+
+    public int getCursorRow() {
+        return mCursorRow;
+    }
+
+    public int getCursorCol() {
+        return mCursorCol;
+    }
+
+    /** Get the terminal cursor style. It will be one of {@link #TERMINAL_CURSOR_STYLES_LIST} */
+    public int getCursorStyle() {
+        return mCursorStyle;
+    }
+
+    /** Set the terminal cursor style. */
+    public void setCursorStyle() {
+        Integer cursorStyle = null;
+
+        if (mClient != null)
+            cursorStyle = mClient.getTerminalCursorStyle();
+
+        if (cursorStyle == null || !Arrays.asList(TERMINAL_CURSOR_STYLES_LIST).contains(cursorStyle))
+            mCursorStyle = DEFAULT_TERMINAL_CURSOR_STYLE;
+        else
+            mCursorStyle = cursorStyle;
+    }
+
+    public boolean isReverseVideo() {
+        return isDecsetInternalBitSet(DECSET_BIT_REVERSE_VIDEO);
+    }
+
+
+
+    public boolean isCursorEnabled() {
+        return isDecsetInternalBitSet(DECSET_BIT_CURSOR_ENABLED);
+    }
+    public boolean shouldCursorBeVisible() {
+        if (!isCursorEnabled())
+            return false;
+        else
+            return mCursorBlinkingEnabled ? mCursorBlinkState : true;
+    }
+
+    public void setCursorBlinkingEnabled(boolean cursorBlinkingEnabled) {
+        this.mCursorBlinkingEnabled = cursorBlinkingEnabled;
+    }
+
+    public void setCursorBlinkState(boolean cursorBlinkState) {
+        this.mCursorBlinkState = cursorBlinkState;
+    }
+
+
+
+    public boolean isKeypadApplicationMode() {
+        return isDecsetInternalBitSet(DECSET_BIT_APPLICATION_KEYPAD);
+    }
+
+    public boolean isCursorKeysApplicationMode() {
+        return isDecsetInternalBitSet(DECSET_BIT_APPLICATION_CURSOR_KEYS);
+    }
+
+    /** If mouse events are being sent as escape codes to the terminal. */
+    public boolean isMouseTrackingActive() {
+        return isDecsetInternalBitSet(DECSET_BIT_MOUSE_TRACKING_PRESS_RELEASE) || isDecsetInternalBitSet(DECSET_BIT_MOUSE_TRACKING_BUTTON_EVENT);
+    }
+
+    private void setDefaultTabStops() {
+        for (int i = 0; i < mColumns; i++)
+            mTabStop[i] = (i & 7) == 0 && i != 0;
+    }
+
+    /**
+     * Accept bytes (typically from the pseudo-teletype) and process them.
+     *
+     * @param buffer a byte array containing the bytes to be processed
+     * @param length the number of bytes in the array to process
+     */
+    public void append(byte[] buffer, int length) {
+        for (int i = 0; i < length; i++)
+            processByte(buffer[i]);
+    }
+
+    private void processByte(byte byteToProcess) {
+        if (mUtf8ToFollow > 0) {
+            if ((byteToProcess & 0b11000000) == 0b10000000) {
+                // 10xxxxxx, a continuation byte.
+                mUtf8InputBuffer[mUtf8Index++] = byteToProcess;
+                if (--mUtf8ToFollow == 0) {
+                    byte firstByteMask = (byte) (mUtf8Index == 2 ? 0b00011111 : (mUtf8Index == 3 ? 0b00001111 : 0b00000111));
+                    int codePoint = (mUtf8InputBuffer[0] & firstByteMask);
+                    for (int i = 1; i < mUtf8Index; i++)
+                        codePoint = ((codePoint << 6) | (mUtf8InputBuffer[i] & 0b00111111));
+                    if (((codePoint <= 0b1111111) && mUtf8Index > 1) || (codePoint < 0b11111111111 && mUtf8Index > 2)
+                        || (codePoint < 0b1111111111111111 && mUtf8Index > 3)) {
+                        // Overlong encoding.
+                        codePoint = UNICODE_REPLACEMENT_CHAR;
+                    }
+
+                    mUtf8Index = mUtf8ToFollow = 0;
+
+                    if (codePoint >= 0x80 && codePoint <= 0x9F) {
+                        // Sequence decoded to a C1 control character which we ignore. They are
+                        // not used nowadays and increases the risk of messing up the terminal state
+                        // on binary input. XTerm does not allow them in utf-8:
+                        // "It is not possible to use a C1 control obtained from decoding the
+                        // UTF-8 text" - http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+                    } else {
+                        switch (Character.getType(codePoint)) {
+                            case Character.UNASSIGNED:
+                            case Character.SURROGATE:
+                                codePoint = UNICODE_REPLACEMENT_CHAR;
+                        }
+                        processCodePoint(codePoint);
+                    }
+                }
+            } else {
+                // Not a UTF-8 continuation byte so replace the entire sequence up to now with the replacement char:
+                mUtf8Index = mUtf8ToFollow = 0;
+                emitCodePoint(UNICODE_REPLACEMENT_CHAR);
+                // The Unicode Standard Version 6.2 – Core Specification
+                // (http://www.unicode.org/versions/Unicode6.2.0/ch03.pdf):
+                // "If the converter encounters an ill-formed UTF-8 code unit sequence which starts with a valid first
+                // byte, but which does not continue with valid successor bytes (see Table 3-7), it must not consume the
+                // successor bytes as part of the ill-formed subsequence
+                // whenever those successor bytes themselves constitute part of a well-formed UTF-8 code unit
+                // subsequence."
+                processByte(byteToProcess);
+            }
+        } else {
+            if ((byteToProcess & 0b10000000) == 0) { // The leading bit is not set so it is a 7-bit ASCII character.
+                processCodePoint(byteToProcess);
+                return;
+            } else if ((byteToProcess & 0b11100000) == 0b11000000) { // 110xxxxx, a two-byte sequence.
+                mUtf8ToFollow = 1;
+            } else if ((byteToProcess & 0b11110000) == 0b11100000) { // 1110xxxx, a three-byte sequence.
+                mUtf8ToFollow = 2;
+            } else if ((byteToProcess & 0b11111000) == 0b11110000) { // 11110xxx, a four-byte sequence.
+                mUtf8ToFollow = 3;
+            } else {
+                // Not a valid UTF-8 sequence start, signal invalid data:
+                processCodePoint(UNICODE_REPLACEMENT_CHAR);
+                return;
+            }
+            mUtf8InputBuffer[mUtf8Index++] = byteToProcess;
+        }
+    }
+
+    public void processCodePoint(int b) {
+        // The Application Program-Control (APC) string might be arbitrary non-printable characters, so handle that early.
+        if (mEscapeState == ESC_APC) {
+            doApc(b);
+            return;
+        } else if (mEscapeState == ESC_APC_ESCAPE) {
+            doApcEscape(b);
+            return;
+        }
+
+        switch (b) {
+            case 0: // Null character (NUL, ^@). Do nothing.
+                break;
+            case 7: // Bell (BEL, ^G, \a). If in an OSC sequence, BEL may terminate a string; otherwise signal bell.
+                if (mEscapeState == ESC_OSC)
+                    doOsc(b);
+                else
+                    mSession.onBell();
+                break;
+            case 8: // Backspace (BS, ^H).
+                if (mLeftMargin == mCursorCol) {
+                    // Jump to previous line if it was auto-wrapped.
+                    int previousRow = mCursorRow - 1;
+                    if (previousRow >= 0 && mScreen.getLineWrap(previousRow)) {
+                        mScreen.clearLineWrap(previousRow);
+                        setCursorRowCol(previousRow, mRightMargin - 1);
+                    }
+                } else {
+                    setCursorCol(mCursorCol - 1);
+                }
+                break;
+            case 9: // Horizontal tab (HT, \t) - move to next tab stop, but not past edge of screen
+                // XXX: Should perhaps use color if writing to new cells. Try with
+                //       printf "\033[41m\tXX\033[0m\n"
+                // The OSX Terminal.app colors the spaces from the tab red, but xterm does not.
+                // Note that Terminal.app only colors on new cells, in e.g.
+                //       printf "\033[41m\t\r\033[42m\tXX\033[0m\n"
+                // the first cells are created with a red background, but when tabbing over
+                // them again with a green background they are not overwritten.
+                mCursorCol = nextTabStop(1);
+                break;
+            case 10: // Line feed (LF, \n).
+            case 11: // Vertical tab (VT, \v).
+            case 12: // Form feed (FF, \f).
+                doLinefeed();
+                break;
+            case 13: // Carriage return (CR, \r).
+                setCursorCol(mLeftMargin);
+                break;
+            case 14: // Shift Out (Ctrl-N, SO) → Switch to Alternate Character Set. This invokes the G1 character set.
+                mUseLineDrawingUsesG0 = false;
+                break;
+            case 15: // Shift In (Ctrl-O, SI) → Switch to Standard Character Set. This invokes the G0 character set.
+                mUseLineDrawingUsesG0 = true;
+                break;
+            case 24: // CAN.
+            case 26: // SUB.
+                if (mEscapeState != ESC_NONE) {
+                    // FIXME: What is this??
+                    mEscapeState = ESC_NONE;
+                    emitCodePoint(127);
+                }
+                break;
+            case 27: // ESC
+                // Starts an escape sequence unless we're parsing a string
+                if (mEscapeState == ESC_P) {
+                    // XXX: Ignore escape when reading device control sequence, since it may be part of string terminator.
+                    return;
+                } else if (mEscapeState != ESC_OSC) {
+                    startEscapeSequence();
+                } else {
+                    doOsc(b);
+                }
+                break;
+            default:
+                mContinueSequence = false;
+                switch (mEscapeState) {
+                    case ESC_NONE:
+                        if (b >= 32) emitCodePoint(b);
+                        break;
+                    case ESC:
+                        doEsc(b);
+                        break;
+                    case ESC_POUND:
+                        doEscPound(b);
+                        break;
+                    case ESC_SELECT_LEFT_PAREN: // Designate G0 Character Set (ISO 2022, VT100).
+                        mUseLineDrawingG0 = (b == '0');
+                        break;
+                    case ESC_SELECT_RIGHT_PAREN: // Designate G1 Character Set (ISO 2022, VT100).
+                        mUseLineDrawingG1 = (b == '0');
+                        break;
+                    case ESC_CSI:
+                        doCsi(b);
+                        break;
+                    case ESC_CSI_UNSUPPORTED_PARAMETER_BYTE:
+                    case ESC_CSI_UNSUPPORTED_INTERMEDIATE_BYTE:
+                        doCsiUnsupportedParameterOrIntermediateByte(b);
+                        break;
+                    case ESC_CSI_EXCLAMATION:
+                        if (b == 'p') { // Soft terminal reset (DECSTR, http://vt100.net/docs/vt510-rm/DECSTR).
+                            reset();
+                        } else {
+                            unknownSequence(b);
+                        }
+                        break;
+                    case ESC_CSI_QUESTIONMARK:
+                        doCsiQuestionMark(b);
+                        break;
+                    case ESC_CSI_BIGGERTHAN:
+                        doCsiBiggerThan(b);
+                        break;
+                    case ESC_CSI_DOLLAR:
+                        boolean originMode = isDecsetInternalBitSet(DECSET_BIT_ORIGIN_MODE);
+                        int effectiveTopMargin = originMode ? mTopMargin : 0;
+                        int effectiveBottomMargin = originMode ? mBottomMargin : mRows;
+                        int effectiveLeftMargin = originMode ? mLeftMargin : 0;
+                        int effectiveRightMargin = originMode ? mRightMargin : mColumns;
+                        switch (b) {
+                            case 'v': // ${CSI}${SRC_TOP}${SRC_LEFT}${SRC_BOTTOM}${SRC_RIGHT}${SRC_PAGE}${DST_TOP}${DST_LEFT}${DST_PAGE}$v"
+                                // Copy rectangular area (DECCRA - http://vt100.net/docs/vt510-rm/DECCRA):
+                                // "If Pbs is greater than Pts, or Pls is greater than Prs, the terminal ignores DECCRA.
+                                // The coordinates of the rectangular area are affected by the setting of origin mode (DECOM).
+                                // DECCRA is not affected by the page margins.
+                                // The copied text takes on the line attributes of the destination area.
+                                // If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, then the value
+                                // is treated as the width or height of that page.
+                                // If the destination area is partially off the page, then DECCRA clips the off-page data.
+                                // DECCRA does not change the active cursor position."
+                                int topSource = Math.min(getArg(0, 1, true) - 1 + effectiveTopMargin, mRows);
+                                int leftSource = Math.min(getArg(1, 1, true) - 1 + effectiveLeftMargin, mColumns);
+                                // Inclusive, so do not subtract one:
+                                int bottomSource = Math.min(Math.max(getArg(2, mRows, true) + effectiveTopMargin, topSource), mRows);
+                                int rightSource = Math.min(Math.max(getArg(3, mColumns, true) + effectiveLeftMargin, leftSource), mColumns);
+                                // int sourcePage = getArg(4, 1, true);
+                                int destionationTop = Math.min(getArg(5, 1, true) - 1 + effectiveTopMargin, mRows);
+                                int destinationLeft = Math.min(getArg(6, 1, true) - 1 + effectiveLeftMargin, mColumns);
+                                // int destinationPage = getArg(7, 1, true);
+                                int heightToCopy = Math.min(mRows - destionationTop, bottomSource - topSource);
+                                int widthToCopy = Math.min(mColumns - destinationLeft, rightSource - leftSource);
+                                mScreen.blockCopy(leftSource, topSource, widthToCopy, heightToCopy, destinationLeft, destionationTop);
+                                break;
+                            case '{': // ${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${"
+                                // Selective erase rectangular area (DECSERA - http://www.vt100.net/docs/vt510-rm/DECSERA).
+                            case 'x': // ${CSI}${CHAR};${TOP}${LEFT}${BOTTOM}${RIGHT}$x"
+                                // Fill rectangular area (DECFRA - http://www.vt100.net/docs/vt510-rm/DECFRA).
+                            case 'z': // ${CSI}$${TOP}${LEFT}${BOTTOM}${RIGHT}$z"
+                                // Erase rectangular area (DECERA - http://www.vt100.net/docs/vt510-rm/DECERA).
+                                boolean erase = b != 'x';
+                                boolean selective = b == '{';
+                                // Only DECSERA keeps visual attributes, DECERA does not:
+                                boolean keepVisualAttributes = erase && selective;
+                                int argIndex = 0;
+                                int fillChar = erase ? ' ' : getArg(argIndex++, -1, true);
+                                // "Pch can be any value from 32 to 126 or from 160 to 255. If Pch is not in this range, then the
+                                // terminal ignores the DECFRA command":
+                                if ((fillChar >= 32 && fillChar <= 126) || (fillChar >= 160 && fillChar <= 255)) {
+                                    // "If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, the value
+                                    // is treated as the width or height of that page."
+                                    int top = Math.min(getArg(argIndex++, 1, true) + effectiveTopMargin, effectiveBottomMargin + 1);
+                                    int left = Math.min(getArg(argIndex++, 1, true) + effectiveLeftMargin, effectiveRightMargin + 1);
+                                    int bottom = Math.min(getArg(argIndex++, mRows, true) + effectiveTopMargin, effectiveBottomMargin);
+                                    int right = Math.min(getArg(argIndex, mColumns, true) + effectiveLeftMargin, effectiveRightMargin);
+                                    long style = getStyle();
+                                    for (int row = top - 1; row < bottom; row++)
+                                        for (int col = left - 1; col < right; col++)
+                                            if (!selective || (TextStyle.decodeEffect(mScreen.getStyleAt(row, col)) & TextStyle.CHARACTER_ATTRIBUTE_PROTECTED) == 0)
+                                                mScreen.setChar(col, row, fillChar, keepVisualAttributes ? mScreen.getStyleAt(row, col) : style);
+                                }
+                                break;
+                            case 'r': // "${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${ATTRIBUTES}$r"
+                                // Change attributes in rectangular area (DECCARA - http://vt100.net/docs/vt510-rm/DECCARA).
+                            case 't': // "${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${ATTRIBUTES}$t"
+                                // Reverse attributes in rectangular area (DECRARA - http://www.vt100.net/docs/vt510-rm/DECRARA).
+                                boolean reverse = b == 't';
+                                // FIXME: "coordinates of the rectangular area are affected by the setting of origin mode (DECOM)".
+                                int top = Math.min(getArg(0, 1, true) - 1, effectiveBottomMargin) + effectiveTopMargin;
+                                int left = Math.min(getArg(1, 1, true) - 1, effectiveRightMargin) + effectiveLeftMargin;
+                                int bottom = Math.min(getArg(2, mRows, true) + 1, effectiveBottomMargin - 1) + effectiveTopMargin;
+                                int right = Math.min(getArg(3, mColumns, true) + 1, effectiveRightMargin - 1) + effectiveLeftMargin;
+                                if (mArgIndex >= 4) {
+                                    if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
+                                    for (int i = 4; i <= mArgIndex; i++) {
+                                        int bits = 0;
+                                        boolean setOrClear = true; // True if setting, false if clearing.
+                                        switch (getArg(i, 0, false)) {
+                                            case 0: // Attributes off (no bold, no underline, no blink, positive image).
+                                                bits = (TextStyle.CHARACTER_ATTRIBUTE_BOLD | TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE | TextStyle.CHARACTER_ATTRIBUTE_BLINK
+                                                    | TextStyle.CHARACTER_ATTRIBUTE_INVERSE);
+                                                if (!reverse) setOrClear = false;
+                                                break;
+                                            case 1: // Bold.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BOLD;
+                                                break;
+                                            case 4: // Underline.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+                                                break;
+                                            case 5: // Blink.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BLINK;
+                                                break;
+                                            case 7: // Negative image.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
+                                                break;
+                                            case 22: // No bold.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BOLD;
+                                                setOrClear = false;
+                                                break;
+                                            case 24: // No underline.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+                                                setOrClear = false;
+                                                break;
+                                            case 25: // No blink.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BLINK;
+                                                setOrClear = false;
+                                                break;
+                                            case 27: // Positive image.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
+                                                setOrClear = false;
+                                                break;
+                                        }
+                                        if (reverse && !setOrClear) {
+                                            // Reverse attributes in rectangular area ignores non-(1,4,5,7) bits.
+                                        } else {
+                                            mScreen.setOrClearEffect(bits, setOrClear, reverse, isDecsetInternalBitSet(DECSET_BIT_RECTANGULAR_CHANGEATTRIBUTE),
+                                                effectiveLeftMargin, effectiveRightMargin, top, left, bottom, right);
+                                        }
+                                    }
+                                } else {
+                                    // Do nothing.
+                                }
+                                break;
+                            default:
+                                unknownSequence(b);
+                        }
+                        break;
+                    case ESC_CSI_DOUBLE_QUOTE:
+                        if (b == 'q') {
+                            // http://www.vt100.net/docs/vt510-rm/DECSCA
+                            int arg = getArg0(0);
+                            if (arg == 0 || arg == 2) {
+                                // DECSED and DECSEL can erase characters.
+                                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_PROTECTED;
+                            } else if (arg == 1) {
+                                // DECSED and DECSEL cannot erase characters.
+                                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_PROTECTED;
+                            } else {
+                                unknownSequence(b);
+                            }
+                        } else {
+                            unknownSequence(b);
+                        }
+                        break;
+                    case ESC_CSI_SINGLE_QUOTE:
+                        if (b == '}') { // Insert Ps Column(s) (default = 1) (DECIC), VT420 and up.
+                            int columnsAfterCursor = mRightMargin - mCursorCol;
+                            int columnsToInsert = Math.min(getArg0(1), columnsAfterCursor);
+                            int columnsToMove = columnsAfterCursor - columnsToInsert;
+                            mScreen.blockCopy(mCursorCol, 0, columnsToMove, mRows, mCursorCol + columnsToInsert, 0);
+                            blockClear(mCursorCol, 0, columnsToInsert, mRows);
+                        } else if (b == '~') { // Delete Ps Column(s) (default = 1) (DECDC), VT420 and up.
+                            int columnsAfterCursor = mRightMargin - mCursorCol;
+                            int columnsToDelete = Math.min(getArg0(1), columnsAfterCursor);
+                            int columnsToMove = columnsAfterCursor - columnsToDelete;
+                            mScreen.blockCopy(mCursorCol + columnsToDelete, 0, columnsToMove, mRows, mCursorCol, 0);
+                        } else {
+                            unknownSequence(b);
+                        }
+                        break;
+                    case ESC_PERCENT:
+                        break;
+                    case ESC_OSC:
+                        doOsc(b);
+                        break;
+                    case ESC_OSC_ESC:
+                        doOscEsc(b);
+                        break;
+                    case ESC_P:
+                        doDeviceControl(b);
+                        break;
+                    case ESC_CSI_QUESTIONMARK_ARG_DOLLAR:
+                        if (b == 'p') {
+                            // Request DEC private mode (DECRQM).
+                            int mode = getArg0(0);
+                            int value;
+                            if (mode == 47 || mode == 1047 || mode == 1049) {
+                                // This state is carried by mScreen pointer.
+                                value = (mScreen == mAltBuffer) ? 1 : 2;
+                            } else {
+                                int internalBit = mapDecSetBitToInternalBit(mode);
+                                if (internalBit != -1) {
+                                    value = isDecsetInternalBitSet(internalBit) ? 1 : 2; // 1=set, 2=reset.
+                                } else {
+                                    Logger.logError(mClient, LOG_TAG, "Got DECRQM for unrecognized private DEC mode=" + mode);
+                                    value = 0; // 0=not recognized, 3=permanently set, 4=permanently reset
+                                }
+                            }
+                            mSession.write(String.format(Locale.US, "\033[?%d;%d$y", mode, value));
+                        } else {
+                            unknownSequence(b);
+                        }
+                        break;
+                    case ESC_CSI_ARGS_SPACE:
+                        int arg = getArg0(0);
+                        switch (b) {
+                            case 'q': // "${CSI}${STYLE} q" - set cursor style (http://www.vt100.net/docs/vt510-rm/DECSCUSR).
+                                switch (arg) {
+                                    case 0: // Blinking block.
+                                    case 1: // Blinking block.
+                                    case 2: // Steady block.
+                                        mCursorStyle = TERMINAL_CURSOR_STYLE_BLOCK;
+                                        break;
+                                    case 3: // Blinking underline.
+                                    case 4: // Steady underline.
+                                        mCursorStyle = TERMINAL_CURSOR_STYLE_UNDERLINE;
+                                        break;
+                                    case 5: // Blinking bar (xterm addition).
+                                    case 6: // Steady bar (xterm addition).
+                                        mCursorStyle = TERMINAL_CURSOR_STYLE_BAR;
+                                        break;
+                                }
+                                break;
+                            case 't':
+                            case 'u':
+                                // Set margin-bell volume - ignore.
+                                break;
+                            default:
+                                unknownSequence(b);
+                        }
+                        break;
+                    case ESC_CSI_ARGS_ASTERIX:
+                        int attributeChangeExtent = getArg0(0);
+                        if (b == 'x' && (attributeChangeExtent >= 0 && attributeChangeExtent <= 2)) {
+                            // Select attribute change extent (DECSACE - http://www.vt100.net/docs/vt510-rm/DECSACE).
+                            setDecsetinternalBit(DECSET_BIT_RECTANGULAR_CHANGEATTRIBUTE, attributeChangeExtent == 2);
+                        } else {
+                            unknownSequence(b);
+                        }
+                        break;
+                    default:
+                        unknownSequence(b);
+                        break;
+                }
+                if (!mContinueSequence) mEscapeState = ESC_NONE;
+                break;
+        }
+    }
+
+    /** When in {@link #ESC_P} ("device control") sequence. */
+    private void doDeviceControl(int b) {
+        switch (b) {
+            case (byte) '\\': // End of ESC \ string Terminator
+            {
+                String dcs = mOSCOrDeviceControlArgs.toString();
+                // DCS $ q P t ST. Request Status String (DECRQSS)
+                if (dcs.startsWith("$q")) {
+                    if (dcs.equals("$q\"p")) {
+                        // DECSCL, conformance level, http://www.vt100.net/docs/vt510-rm/DECSCL:
+                        String csiString = "64;1\"p";
+                        mSession.write("\033P1$r" + csiString + "\033\\");
+                    } else {
+                        finishSequenceAndLogError("Unrecognized DECRQSS string: '" + dcs + "'");
+                    }
+                } else if (dcs.startsWith("+q")) {
+                    // Request Termcap/Terminfo String. The string following the "q" is a list of names encoded in
+                    // hexadecimal (2 digits per character) separated by ; which correspond to termcap or terminfo key
+                    // names.
+                    // Two special features are also recognized, which are not key names: Co for termcap colors (or colors
+                    // for terminfo colors), and TN for termcap name (or name for terminfo name).
+                    // xterm responds with DCS 1 + r P t ST for valid requests, adding to P t an = , and the value of the
+                    // corresponding string that xterm would send, or DCS 0 + r P t ST for invalid requests. The strings are
+                    // encoded in hexadecimal (2 digits per character).
+                    // Example:
+                    // :kr=\EOC: ks=\E[?1h\E=: ku=\EOA: le=^H:mb=\E[5m:md=\E[1m:\
+                    // where
+                    // kd=down-arrow key
+                    // kl=left-arrow key
+                    // kr=right-arrow key
+                    // ku=up-arrow key
+                    // #2=key_shome, "shifted home"
+                    // #4=key_sleft, "shift arrow left"
+                    // %i=key_sright, "shift arrow right"
+                    // *7=key_send, "shifted end"
+                    // k1=F1 function key
+
+                    // Example: Request for ku is "ESC P + q 6 b 7 5 ESC \", where 6b7d=ku in hexadecimal.
+                    // Xterm response in normal cursor mode:
+                    // "<27> P 1 + r 6 b 7 5 = 1 B 5 B 4 1" where 0x1B 0x5B 0x41 = 27 91 65 = ESC [ A
+                    // Xterm response in application cursor mode:
+                    // "<27> P 1 + r 6 b 7 5 = 1 B 5 B 4 1" where 0x1B 0x4F 0x41 = 27 91 65 = ESC 0 A
+
+                    // #4 is "shift arrow left":
+                    // *** Device Control (DCS) for '#4'- 'ESC P + q 23 34 ESC \'
+                    // Response: <27> P 1 + r 2 3 3 4 = 1 B 5 B 3 1 3 B 3 2 4 4 <27> \
+                    // where 0x1B 0x5B 0x31 0x3B 0x32 0x44 = ESC [ 1 ; 2 D
+                    // which we find in: TermKeyListener.java: KEY_MAP.put(KEYMOD_SHIFT | KEYCODE_DPAD_LEFT, "\033[1;2D");
+
+                    // See http://h30097.www3.hp.com/docs/base_doc/DOCUMENTATION/V40G_HTML/MAN/MAN4/0178____.HTM for what to
+                    // respond, as well as http://www.freebsd.org/cgi/man.cgi?query=termcap&sektion=5#CAPABILITIES for
+                    // the meaning of e.g. "ku", "kd", "kr", "kl"
+
+                    for (String part : dcs.substring(2).split(";")) {
+                        if (part.length() % 2 == 0) {
+                            StringBuilder transBuffer = new StringBuilder();
+                            char c;
+                            for (int i = 0; i < part.length(); i += 2) {
+                                try {
+                                    c = (char) Long.decode("0x" + part.charAt(i) + "" + part.charAt(i + 1)).longValue();
+                                } catch (NumberFormatException e) {
+                                    Logger.logStackTraceWithMessage(mClient, LOG_TAG, "Invalid device termcap/terminfo encoded name \"" + part + "\"", e);
+                                    continue;
+                                }
+                                transBuffer.append(c);
+                            }
+
+                            String trans = transBuffer.toString();
+                            String responseValue;
+                            switch (trans) {
+                                case "Co":
+                                case "colors":
+                                    responseValue = "256"; // Number of colors.
+                                    break;
+                                case "TN":
+                                case "name":
+                                    responseValue = "xterm";
+                                    break;
+                                default:
+                                    responseValue = KeyHandler.getCodeFromTermcap(trans, isDecsetInternalBitSet(DECSET_BIT_APPLICATION_CURSOR_KEYS),
+                                        isDecsetInternalBitSet(DECSET_BIT_APPLICATION_KEYPAD));
+                                    break;
+                            }
+                            if (responseValue == null) {
+                                switch (trans) {
+                                    case "%1": // Help key - ignore
+                                    case "&8": // Undo key - ignore.
+                                        break;
+                                    default:
+                                        Logger.logWarn(mClient, LOG_TAG, "Unhandled termcap/terminfo name: '" + trans + "'");
+                                }
+                                // Respond with invalid request:
+                                mSession.write("\033P0+r" + part + "\033\\");
+                            } else {
+                                StringBuilder hexEncoded = new StringBuilder();
+                                for (int j = 0; j < responseValue.length(); j++) {
+                                    hexEncoded.append(String.format("%02X", (int) responseValue.charAt(j)));
+                                }
+                                mSession.write("\033P1+r" + part + "=" + hexEncoded + "\033\\");
+                            }
+                        } else {
+                            Logger.logError(mClient, LOG_TAG, "Invalid device termcap/terminfo name of odd length: " + part);
+                        }
+                    }
+                } else {
+                    if (LOG_ESCAPE_SEQUENCES)
+                        Logger.logError(mClient, LOG_TAG, "Unrecognized device control string: " + dcs);
+                }
+                finishSequence();
+            }
+            break;
+            default:
+                if (mOSCOrDeviceControlArgs.length() > MAX_OSC_STRING_LENGTH) {
+                    // Too long.
+                    mOSCOrDeviceControlArgs.setLength(0);
+                    finishSequence();
+                } else {
+                    mOSCOrDeviceControlArgs.appendCodePoint(b);
+                    continueSequence(mEscapeState);
+                }
+        }
+    }
+
+    /**
+     * When in {@link #ESC_APC} (APC, Application Program Command) sequence.
+     */
+    private void doApc(int b) {
+        if (b == 27) {
+            continueSequence(ESC_APC_ESCAPE);
+        }
+        // Eat APC sequences silently for now.
+    }
+
+    /**
+     * When in {@link #ESC_APC} (APC, Application Program Command) sequence.
+     */
+    private void doApcEscape(int b) {
+        if (b == '\\') {
+            // A String Terminator (ST), ending the APC escape sequence.
+            finishSequence();
+        } else {
+            // The Escape character was not the start of a String Terminator (ST),
+            // but instead just data inside of the APC escape sequence.
+            continueSequence(ESC_APC);
+        }
+    }
+
+    private int nextTabStop(int numTabs) {
+        for (int i = mCursorCol + 1; i < mColumns; i++)
+            if (mTabStop[i] && --numTabs == 0) return Math.min(i, mRightMargin);
+        return mRightMargin - 1;
+    }
+
+    /**
+     * Process byte while in the {@link #ESC_CSI_UNSUPPORTED_PARAMETER_BYTE} or
+     * {@link #ESC_CSI_UNSUPPORTED_INTERMEDIATE_BYTE} escape state.
+     *
+     * Parse unsupported parameter, intermediate and final bytes but ignore them.
+     *
+     * > For Control Sequence Introducer, ... the ESC [ is followed by
+     * > - any number (including none) of "parameter bytes" in the range 0x30–0x3F (ASCII 0–9:;<=>?),
+     * > - then by any number of "intermediate bytes" in the range 0x20–0x2F (ASCII space and !"#$%&'()*+,-./),
+     * > - then finally by a single "final byte" in the range 0x40–0x7E (ASCII @A–Z[\]^_`a–z{|}~).
+     *
+     * - https://en.wikipedia.org/wiki/ANSI_escape_code#Control_Sequence_Introducer_commands
+     * - https://invisible-island.net/xterm/ecma-48-parameter-format.html#section5.4
+     */
+    private void doCsiUnsupportedParameterOrIntermediateByte(int b) {
+        if (mEscapeState == ESC_CSI_UNSUPPORTED_PARAMETER_BYTE && b >= 0x30 && b <= 0x3F) {
+            // Supported `0–9:;>?` or unsupported `<=` parameter byte after an
+            // initial unsupported parameter byte in `doCsi()`, or a sequential parameter byte.
+            continueSequence(ESC_CSI_UNSUPPORTED_PARAMETER_BYTE);
+        } else if (b >= 0x20 && b <= 0x2F) {
+            // Optional intermediate byte `!"#$%&'()*+,-./` after parameter or intermediate byte.
+            continueSequence(ESC_CSI_UNSUPPORTED_INTERMEDIATE_BYTE);
+        } else if (b >= 0x40 && b <= 0x7E) {
+            // Final byte `@A–Z[\]^_`a–z{|}~` after parameter or intermediate byte.
+            // Calling `unknownSequence()` would log an error with only a final byte, so ignore it for now.
+            finishSequence();
+        } else {
+            unknownSequence(b);
+        }
+    }
+
+    /** Process byte while in the {@link #ESC_CSI_QUESTIONMARK} escape state. */
+    private void doCsiQuestionMark(int b) {
+        switch (b) {
+            case 'J': // Selective erase in display (DECSED) - http://www.vt100.net/docs/vt510-rm/DECSED.
+            case 'K': // Selective erase in line (DECSEL) - http://vt100.net/docs/vt510-rm/DECSEL.
+                mAboutToAutoWrap = false;
+                int fillChar = ' ';
+                int startCol = -1;
+                int startRow = -1;
+                int endCol = -1;
+                int endRow = -1;
+                boolean justRow = (b == 'K');
+                switch (getArg0(0)) {
+                    case 0: // Erase from the active position to the end, inclusive (default).
+                        startCol = mCursorCol;
+                        startRow = mCursorRow;
+                        endCol = mColumns;
+                        endRow = justRow ? (mCursorRow + 1) : mRows;
+                        break;
+                    case 1: // Erase from start to the active position, inclusive.
+                        startCol = 0;
+                        startRow = justRow ? mCursorRow : 0;
+                        endCol = mCursorCol + 1;
+                        endRow = mCursorRow + 1;
+                        break;
+                    case 2: // Erase all of the display/line.
+                        startCol = 0;
+                        startRow = justRow ? mCursorRow : 0;
+                        endCol = mColumns;
+                        endRow = justRow ? (mCursorRow + 1) : mRows;
+                        break;
+                    default:
+                        unknownSequence(b);
+                        break;
+                }
+                long style = getStyle();
+                for (int row = startRow; row < endRow; row++) {
+                    for (int col = startCol; col < endCol; col++) {
+                        if ((TextStyle.decodeEffect(mScreen.getStyleAt(row, col)) & TextStyle.CHARACTER_ATTRIBUTE_PROTECTED) == 0)
+                            mScreen.setChar(col, row, fillChar, style);
+                    }
+                }
+                break;
+            case 'h':
+            case 'l':
+                if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
+                for (int i = 0; i <= mArgIndex; i++)
+                    doDecSetOrReset(b == 'h', mArgs[i]);
+                break;
+            case 'n': // Device Status Report (DSR, DEC-specific).
+                switch (getArg0(-1)) {
+                    case 6:
+                        // Extended Cursor Position (DECXCPR - http://www.vt100.net/docs/vt510-rm/DECXCPR). Page=1.
+                        mSession.write(String.format(Locale.US, "\033[?%d;%d;1R", mCursorRow + 1, mCursorCol + 1));
+                        break;
+                    default:
+                        finishSequence();
+                        return;
+                }
+                break;
+            case 'r':
+            case 's':
+                if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
+                for (int i = 0; i <= mArgIndex; i++) {
+                    int externalBit = mArgs[i];
+                    int internalBit = mapDecSetBitToInternalBit(externalBit);
+                    if (internalBit == -1) {
+                        Logger.logWarn(mClient, LOG_TAG, "Ignoring request to save/recall decset bit=" + externalBit);
+                    } else {
+                        if (b == 's') {
+                            mSavedDecSetFlags |= internalBit;
+                        } else {
+                            doDecSetOrReset((mSavedDecSetFlags & internalBit) != 0, externalBit);
+                        }
+                    }
+                }
+                break;
+            case '$':
+                continueSequence(ESC_CSI_QUESTIONMARK_ARG_DOLLAR);
+                return;
+            default:
+                parseArg(b);
+        }
+    }
+
+    public void doDecSetOrReset(boolean setting, int externalBit) {
+        int internalBit = mapDecSetBitToInternalBit(externalBit);
+        if (internalBit != -1) {
+            setDecsetinternalBit(internalBit, setting);
+        }
+        switch (externalBit) {
+            case 1: // Application Cursor Keys (DECCKM).
+                break;
+            case 3: // Set: 132 column mode (. Reset: 80 column mode. ANSI name: DECCOLM.
+                // We don't actually set/reset 132 cols, but we do want the side effects
+                // (FIXME: Should only do this if the 95 DECSET bit (DECNCSM) is set, and if changing value?):
+                // Sets the left, right, top and bottom scrolling margins to their default positions, which is important for
+                // the "reset" utility to really reset the terminal:
+                mLeftMargin = mTopMargin = 0;
+                mBottomMargin = mRows;
+                mRightMargin = mColumns;
+                // "DECCOLM resets vertical split screen mode (DECLRMM) to unavailable":
+                setDecsetinternalBit(DECSET_BIT_LEFTRIGHT_MARGIN_MODE, false);
+                // "Erases all data in page memory":
+                blockClear(0, 0, mColumns, mRows);
+                setCursorRowCol(0, 0);
+                break;
+            case 4: // DECSCLM-Scrolling Mode. Ignore.
+                break;
+            case 5: // Reverse video. No action.
+                break;
+            case 6: // Set: Origin Mode. Reset: Normal Cursor Mode. Ansi name: DECOM.
+                if (setting) setCursorPosition(0, 0);
+                break;
+            case 7: // Wrap-around bit, not specific action.
+            case 8: // Auto-repeat Keys (DECARM). Do not implement.
+            case 9: // X10 mouse reporting - outdated. Do not implement.
+            case 12: // Control cursor blinking - ignore.
+            case 25: // Hide/show cursor - no action needed, renderer will check with shouldCursorBeVisible().
+                if (mClient != null)
+                    mClient.onTerminalCursorStateChange(setting);
+                break;
+            case 40: // Allow 80 => 132 Mode, ignore.
+            case 45: // TODO: Reverse wrap-around. Implement???
+            case 66: // Application keypad (DECNKM).
+                break;
+            case 69: // Left and right margin mode (DECLRMM).
+                if (!setting) {
+                    mLeftMargin = 0;
+                    mRightMargin = mColumns;
+                }
+                break;
+            case 1000:
+            case 1001:
+            case 1002:
+            case 1003:
+            case 1004:
+            case 1005: // UTF-8 mouse mode, ignore.
+            case 1006: // SGR Mouse Mode
+            case 1015:
+            case 1034: // Interpret "meta" key, sets eighth bit.
+                break;
+            case 1048: // Set: Save cursor as in DECSC. Reset: Restore cursor as in DECRC.
+                if (setting)
+                    saveCursor();
+                else
+                    restoreCursor();
+                break;
+            case 47:
+            case 1047:
+            case 1049: {
+                // Set: Save cursor as in DECSC and use Alternate Screen Buffer, clearing it first.
+                // Reset: Use Normal Screen Buffer and restore cursor as in DECRC.
+                TerminalBuffer newScreen = setting ? mAltBuffer : mMainBuffer;
+                if (newScreen != mScreen) {
+                    boolean resized = !(newScreen.mColumns == mColumns && newScreen.mScreenRows == mRows);
+                    if (setting) saveCursor();
+                    mScreen = newScreen;
+                    if (!setting) {
+                        int col = mSavedStateMain.mSavedCursorCol;
+                        int row = mSavedStateMain.mSavedCursorRow;
+                        restoreCursor();
+                        if (resized) {
+                            // Restore cursor position _not_ clipped to current screen (let resizeScreen() handle that):
+                            mCursorCol = col;
+                            mCursorRow = row;
+                        }
+                    }
+                    // Check if buffer size needs to be updated:
+                    if (resized) resizeScreen();
+                    // Clear new screen if alt buffer:
+                    if (newScreen == mAltBuffer)
+                        newScreen.blockSet(0, 0, mColumns, mRows, ' ', getStyle());
+                }
+                break;
+            }
+            case 2004:
+                // Bracketed paste mode - setting bit is enough.
+                break;
+            default:
+                unknownParameter(externalBit);
+                break;
+        }
+    }
+
+    private void doCsiBiggerThan(int b) {
+        switch (b) {
+            case 'c': // "${CSI}>c" or "${CSI}>c". Secondary Device Attributes (DA2).
+                // Originally this was used for the terminal to respond with "identification code, firmware version level,
+                // and hardware options" (http://vt100.net/docs/vt510-rm/DA2), with the first "41" meaning the VT420
+                // terminal type. This is not used anymore, but the second version level field has been changed by xterm
+                // to mean it's release number ("patch numbers" listed at http://invisible-island.net/xterm/xterm.log.html),
+                // and some applications use it as a feature check:
+                // * tmux used to have a "xterm won't reach version 500 for a while so set that as the upper limit" check,
+                // and then check "xterm_version > 270" if rectangular area operations such as DECCRA could be used.
+                // * vim checks xterm version number >140 for "Request termcap/terminfo string" functionality >276 for SGR
+                // mouse report.
+                // The third number is a keyboard identifier not used nowadays.
+                mSession.write("\033[>41;320;0c");
+                break;
+            case 'm':
+                // https://bugs.launchpad.net/gnome-terminal/+bug/96676/comments/25
+                // Depending on the first number parameter, this can set one of the xterm resources
+                // modifyKeyboard, modifyCursorKeys, modifyFunctionKeys and modifyOtherKeys.
+                // http://invisible-island.net/xterm/manpage/xterm.html#RESOURCES
+
+                // * modifyKeyboard (parameter=1):
+                // Normally xterm makes a special case regarding modifiers (shift, control, etc.) to handle special keyboard
+                // layouts (legacy and vt220). This is done to provide compatible keyboards for DEC VT220 and related
+                // terminals that implement user-defined keys (UDK).
+                // The bits of the resource value selectively enable modification of the given category when these keyboards
+                // are selected. The default is "0":
+                // (0) The legacy/vt220 keyboards interpret only the Control-modifier when constructing numbered
+                // function-keys. Other special keys are not modified.
+                // (1) allows modification of the numeric keypad
+                // (2) allows modification of the editing keypad
+                // (4) allows modification of function-keys, overrides use of Shift-modifier for UDK.
+                // (8) allows modification of other special keys
+
+                // * modifyCursorKeys (parameter=2):
+                // Tells how to handle the special case where Control-, Shift-, Alt- or Meta-modifiers are used to add a
+                // parameter to the escape sequence returned by a cursor-key. The default is "2".
+                // - Set it to -1 to disable it.
+                // - Set it to 0 to use the old/obsolete behavior.
+                // - Set it to 1 to prefix modified sequences with CSI.
+                // - Set it to 2 to force the modifier to be the second parameter if it would otherwise be the first.
+                // - Set it to 3 to mark the sequence with a ">" to hint that it is private.
+
+                // * modifyFunctionKeys (parameter=3):
+                // Tells how to handle the special case where Control-, Shift-, Alt- or Meta-modifiers are used to add a
+                // parameter to the escape sequence returned by a (numbered) function-
+                // key. The default is "2". The resource values are similar to modifyCursorKeys:
+                // Set it to -1 to permit the user to use shift- and control-modifiers to construct function-key strings
+                // using the normal encoding scheme.
+                // - Set it to 0 to use the old/obsolete behavior.
+                // - Set it to 1 to prefix modified sequences with CSI.
+                // - Set it to 2 to force the modifier to be the second parameter if it would otherwise be the first.
+                // - Set it to 3 to mark the sequence with a ">" to hint that it is private.
+                // If modifyFunctionKeys is zero, xterm uses Control- and Shift-modifiers to allow the user to construct
+                // numbered function-keys beyond the set provided by the keyboard:
+                // (Control) adds the value given by the ctrlFKeys resource.
+                // (Shift) adds twice the value given by the ctrlFKeys resource.
+                // (Control/Shift) adds three times the value given by the ctrlFKeys resource.
+                //
+                // As a special case, legacy (when oldFunctionKeys is true) or vt220 (when sunKeyboard is true)
+                // keyboards interpret only the Control-modifier when constructing numbered function-keys.
+                // This is done to provide compatible keyboards for DEC VT220 and related terminals that
+                // implement user-defined keys (UDK).
+
+                // * modifyOtherKeys (parameter=4):
+                // Like modifyCursorKeys, tells xterm to construct an escape sequence for other keys (such as "2") when
+                // modified by Control-, Alt- or Meta-modifiers. This feature does not apply to function keys and
+                // well-defined keys such as ESC or the control keys. The default is "0".
+                // (0) disables this feature.
+                // (1) enables this feature for keys except for those with well-known behavior, e.g., Tab, Backarrow and
+                // some special control character cases, e.g., Control-Space to make a NUL.
+                // (2) enables this feature for keys including the exceptions listed.
+                Logger.logError(mClient, LOG_TAG, "(ignored) CSI > MODIFY RESOURCE: " + getArg0(-1) + " to " + getArg1(-1));
+                break;
+            default:
+                parseArg(b);
+                break;
+        }
+    }
+
+    private void startEscapeSequence() {
+        mEscapeState = ESC;
+        mArgIndex = 0;
+        Arrays.fill(mArgs, -1);
+        mArgsSubParamsBitSet = 0;
+    }
+
+    private void doLinefeed() {
+        boolean belowScrollingRegion = mCursorRow >= mBottomMargin;
+        int newCursorRow = mCursorRow + 1;
+        if (belowScrollingRegion) {
+            // Move down (but not scroll) as long as we are above the last row.
+            if (mCursorRow != mRows - 1) {
+                setCursorRow(newCursorRow);
+            }
+        } else {
+            if (newCursorRow == mBottomMargin) {
+                scrollDownOneLine();
+                newCursorRow = mBottomMargin - 1;
+            }
+            setCursorRow(newCursorRow);
+        }
+    }
+
+    private void continueSequence(int state) {
+        mEscapeState = state;
+        mContinueSequence = true;
+    }
+
+    private void doEscPound(int b) {
+        switch (b) {
+            case '8': // Esc # 8 - DEC screen alignment test - fill screen with E's.
+                mScreen.blockSet(0, 0, mColumns, mRows, 'E', getStyle());
+                break;
+            default:
+                unknownSequence(b);
+                break;
+        }
+    }
+
+    /** Encountering a character in the {@link #ESC} state. */
+    private void doEsc(int b) {
+        switch (b) {
+            case '#':
+                continueSequence(ESC_POUND);
+                break;
+            case '(':
+                continueSequence(ESC_SELECT_LEFT_PAREN);
+                break;
+            case ')':
+                continueSequence(ESC_SELECT_RIGHT_PAREN);
+                break;
+            case '6': // Back index (http://www.vt100.net/docs/vt510-rm/DECBI). Move left, insert blank column if start.
+                if (mCursorCol > mLeftMargin) {
+                    mCursorCol--;
+                } else {
+                    int rows = mBottomMargin - mTopMargin;
+                    mScreen.blockCopy(mLeftMargin, mTopMargin, mRightMargin - mLeftMargin - 1, rows, mLeftMargin + 1, mTopMargin);
+                    mScreen.blockSet(mLeftMargin, mTopMargin, 1, rows, ' ', TextStyle.encode(mForeColor, mBackColor, 0));
+                }
+                break;
+            case '7': // DECSC save cursor - http://www.vt100.net/docs/vt510-rm/DECSC
+                saveCursor();
+                break;
+            case '8': // DECRC restore cursor - http://www.vt100.net/docs/vt510-rm/DECRC
+                restoreCursor();
+                break;
+            case '9': // Forward Index (http://www.vt100.net/docs/vt510-rm/DECFI). Move right, insert blank column if end.
+                if (mCursorCol < mRightMargin - 1) {
+                    mCursorCol++;
+                } else {
+                    int rows = mBottomMargin - mTopMargin;
+                    mScreen.blockCopy(mLeftMargin + 1, mTopMargin, mRightMargin - mLeftMargin - 1, rows, mLeftMargin, mTopMargin);
+                    mScreen.blockSet(mRightMargin - 1, mTopMargin, 1, rows, ' ', TextStyle.encode(mForeColor, mBackColor, 0));
+                }
+                break;
+            case 'c': // RIS - Reset to Initial State (http://vt100.net/docs/vt510-rm/RIS).
+                reset();
+                mMainBuffer.clearTranscript();
+                blockClear(0, 0, mColumns, mRows);
+                setCursorPosition(0, 0);
+                break;
+            case 'D': // INDEX
+                doLinefeed();
+                break;
+            case 'E': // Next line (http://www.vt100.net/docs/vt510-rm/NEL).
+                setCursorCol(isDecsetInternalBitSet(DECSET_BIT_ORIGIN_MODE) ? mLeftMargin : 0);
+                doLinefeed();
+                break;
+            case 'F': // Cursor to lower-left corner of screen
+                setCursorRowCol(0, mBottomMargin - 1);
+                break;
+            case 'H': // Tab set
+                mTabStop[mCursorCol] = true;
+                break;
+            case 'M': // "${ESC}M" - reverse index (RI).
+                // http://www.vt100.net/docs/vt100-ug/chapter3.html: "Move the active position to the same horizontal
+                // position on the preceding line. If the active position is at the top margin, a scroll down is performed".
+                if (mCursorRow <= mTopMargin) {
+                    mScreen.blockCopy(mLeftMargin, mTopMargin, mRightMargin - mLeftMargin, mBottomMargin - (mTopMargin + 1), mLeftMargin, mTopMargin + 1);
+                    blockClear(mLeftMargin, mTopMargin, mRightMargin - mLeftMargin);
+                } else {
+                    mCursorRow--;
+                }
+                break;
+            case 'N': // SS2, ignore.
+            case '0': // SS3, ignore.
+                break;
+            case 'P': // Device control string
+                mOSCOrDeviceControlArgs.setLength(0);
+                continueSequence(ESC_P);
+                break;
+            case '[':
+                continueSequence(ESC_CSI);
+                break;
+            case '=': // DECKPAM
+                setDecsetinternalBit(DECSET_BIT_APPLICATION_KEYPAD, true);
+                break;
+            case ']': // OSC
+                mOSCOrDeviceControlArgs.setLength(0);
+                continueSequence(ESC_OSC);
+                break;
+            case '>': // DECKPNM
+                setDecsetinternalBit(DECSET_BIT_APPLICATION_KEYPAD, false);
+                break;
+            case '_': // APC - Application Program Command.
+                continueSequence(ESC_APC);
+                break;
+            default:
+                unknownSequence(b);
+                break;
+        }
+    }
+
+    /** DECSC save cursor - http://www.vt100.net/docs/vt510-rm/DECSC . See {@link #restoreCursor()}. */
+    private void saveCursor() {
+        SavedScreenState state = (mScreen == mMainBuffer) ? mSavedStateMain : mSavedStateAlt;
+        state.mSavedCursorRow = mCursorRow;
+        state.mSavedCursorCol = mCursorCol;
+        state.mSavedEffect = mEffect;
+        state.mSavedForeColor = mForeColor;
+        state.mSavedBackColor = mBackColor;
+        state.mSavedDecFlags = mCurrentDecSetFlags;
+        state.mUseLineDrawingG0 = mUseLineDrawingG0;
+        state.mUseLineDrawingG1 = mUseLineDrawingG1;
+        state.mUseLineDrawingUsesG0 = mUseLineDrawingUsesG0;
+    }
+
+    /** DECRS restore cursor - http://www.vt100.net/docs/vt510-rm/DECRC. See {@link #saveCursor()}. */
+    private void restoreCursor() {
+        SavedScreenState state = (mScreen == mMainBuffer) ? mSavedStateMain : mSavedStateAlt;
+        setCursorRowCol(state.mSavedCursorRow, state.mSavedCursorCol);
+        mEffect = state.mSavedEffect;
+        mForeColor = state.mSavedForeColor;
+        mBackColor = state.mSavedBackColor;
+        int mask = (DECSET_BIT_AUTOWRAP | DECSET_BIT_ORIGIN_MODE);
+        mCurrentDecSetFlags = (mCurrentDecSetFlags & ~mask) | (state.mSavedDecFlags & mask);
+        mUseLineDrawingG0 = state.mUseLineDrawingG0;
+        mUseLineDrawingG1 = state.mUseLineDrawingG1;
+        mUseLineDrawingUsesG0 = state.mUseLineDrawingUsesG0;
+    }
+
+    /** Following a CSI - Control Sequence Introducer, "\033[". {@link #ESC_CSI}. */
+    private void doCsi(int b) {
+        switch (b) {
+            case '!':
+                continueSequence(ESC_CSI_EXCLAMATION);
+                break;
+            case '"':
+                continueSequence(ESC_CSI_DOUBLE_QUOTE);
+                break;
+            case '\'':
+                continueSequence(ESC_CSI_SINGLE_QUOTE);
+                break;
+            case '$':
+                continueSequence(ESC_CSI_DOLLAR);
+                break;
+            case '*':
+                continueSequence(ESC_CSI_ARGS_ASTERIX);
+                break;
+            case '@': {
+                // "CSI{n}@" - Insert ${n} space characters (ICH) - http://www.vt100.net/docs/vt510-rm/ICH.
+                mAboutToAutoWrap = false;
+                int columnsAfterCursor = mColumns - mCursorCol;
+                int spacesToInsert = Math.min(getArg0(1), columnsAfterCursor);
+                int charsToMove = columnsAfterCursor - spacesToInsert;
+                mScreen.blockCopy(mCursorCol, mCursorRow, charsToMove, 1, mCursorCol + spacesToInsert, mCursorRow);
+                blockClear(mCursorCol, mCursorRow, spacesToInsert);
+            }
+            break;
+            case 'A': // "CSI${n}A" - Cursor up (CUU) ${n} rows.
+                setCursorRow(Math.max(0, mCursorRow - getArg0(1)));
+                break;
+            case 'B': // "CSI${n}B" - Cursor down (CUD) ${n} rows.
+                setCursorRow(Math.min(mRows - 1, mCursorRow + getArg0(1)));
+                break;
+            case 'C': // "CSI${n}C" - Cursor forward (CUF).
+            case 'a': // "CSI${n}a" - Horizontal position relative (HPR). From ISO-6428/ECMA-48.
+                setCursorCol(Math.min(mRightMargin - 1, mCursorCol + getArg0(1)));
+                break;
+            case 'D': // "CSI${n}D" - Cursor backward (CUB) ${n} columns.
+                setCursorCol(Math.max(mLeftMargin, mCursorCol - getArg0(1)));
+                break;
+            case 'E': // "CSI{n}E - Cursor Next Line (CNL). From ISO-6428/ECMA-48.
+                setCursorPosition(0, mCursorRow + getArg0(1));
+                break;
+            case 'F': // "CSI{n}F - Cursor Previous Line (CPL). From ISO-6428/ECMA-48.
+                setCursorPosition(0, mCursorRow - getArg0(1));
+                break;
+            case 'G': // "CSI${n}G" - Cursor horizontal absolute (CHA) to column ${n}.
+                setCursorCol(Math.min(Math.max(1, getArg0(1)), mColumns) - 1);
+                break;
+            case 'H': // "${CSI}${ROW};${COLUMN}H" - Cursor position (CUP).
+            case 'f': // "${CSI}${ROW};${COLUMN}f" - Horizontal and Vertical Position (HVP).
+                setCursorPosition(getArg1(1) - 1, getArg0(1) - 1);
+                break;
+            case 'I': // Cursor Horizontal Forward Tabulation (CHT). Move the active position n tabs forward.
+                setCursorCol(nextTabStop(getArg0(1)));
+                break;
+            case 'J': // "${CSI}${0,1,2,3}J" - Erase in Display (ED)
+                // ED ignores the scrolling margins.
+                switch (getArg0(0)) {
+                    case 0: // Erase from the active position to the end of the screen, inclusive (default).
+                        blockClear(mCursorCol, mCursorRow, mColumns - mCursorCol);
+                        blockClear(0, mCursorRow + 1, mColumns, mRows - (mCursorRow + 1));
+                        break;
+                    case 1: // Erase from start of the screen to the active position, inclusive.
+                        blockClear(0, 0, mColumns, mCursorRow);
+                        blockClear(0, mCursorRow, mCursorCol + 1);
+                        break;
+                    case 2: // Erase all of the display - all lines are erased, changed to single-width, and the cursor does not
+                        // move..
+                        blockClear(0, 0, mColumns, mRows);
+                        break;
+                    case 3: // Delete all lines saved in the scrollback buffer (xterm etc)
+                        mMainBuffer.clearTranscript();
+                        break;
+                    default:
+                        unknownSequence(b);
+                        return;
+                }
+                mAboutToAutoWrap = false;
+                break;
+            case 'K': // "CSI{n}K" - Erase in line (EL).
+                switch (getArg0(0)) {
+                    case 0: // Erase from the cursor to the end of the line, inclusive (default)
+                        blockClear(mCursorCol, mCursorRow, mColumns - mCursorCol);
+                        break;
+                    case 1: // Erase from the start of the screen to the cursor, inclusive.
+                        blockClear(0, mCursorRow, mCursorCol + 1);
+                        break;
+                    case 2: // Erase all of the line.
+                        blockClear(0, mCursorRow, mColumns);
+                        break;
+                    default:
+                        unknownSequence(b);
+                        return;
+                }
+                mAboutToAutoWrap = false;
+                break;
+            case 'L': // "${CSI}{N}L" - insert ${N} lines (IL).
+            {
+                int linesAfterCursor = mBottomMargin - mCursorRow;
+                int linesToInsert = Math.min(getArg0(1), linesAfterCursor);
+                int linesToMove = linesAfterCursor - linesToInsert;
+                mScreen.blockCopy(0, mCursorRow, mColumns, linesToMove, 0, mCursorRow + linesToInsert);
+                blockClear(0, mCursorRow, mColumns, linesToInsert);
+            }
+            break;
+            case 'M': // "${CSI}${N}M" - delete N lines (DL).
+            {
+                mAboutToAutoWrap = false;
+                int linesAfterCursor = mBottomMargin - mCursorRow;
+                int linesToDelete = Math.min(getArg0(1), linesAfterCursor);
+                int linesToMove = linesAfterCursor - linesToDelete;
+                mScreen.blockCopy(0, mCursorRow + linesToDelete, mColumns, linesToMove, 0, mCursorRow);
+                blockClear(0, mCursorRow + linesToMove, mColumns, linesToDelete);
+            }
+            break;
+            case 'P': // "${CSI}{N}P" - delete ${N} characters (DCH).
+            {
+                // http://www.vt100.net/docs/vt510-rm/DCH: "If ${N} is greater than the number of characters between the
+                // cursor and the right margin, then DCH only deletes the remaining characters.
+                // As characters are deleted, the remaining characters between the cursor and right margin move to the left.
+                // Character attributes move with the characters. The terminal adds blank spaces with no visual character
+                // attributes at the right margin. DCH has no effect outside the scrolling margins."
+                mAboutToAutoWrap = false;
+                int cellsAfterCursor = mColumns - mCursorCol;
+                int cellsToDelete = Math.min(getArg0(1), cellsAfterCursor);
+                int cellsToMove = cellsAfterCursor - cellsToDelete;
+                mScreen.blockCopy(mCursorCol + cellsToDelete, mCursorRow, cellsToMove, 1, mCursorCol, mCursorRow);
+                blockClear(mCursorCol + cellsToMove, mCursorRow, cellsToDelete);
+            }
+            break;
+            case 'S': { // "${CSI}${N}S" - scroll up ${N} lines (default = 1) (SU).
+                final int linesToScroll = getArg0(1);
+                for (int i = 0; i < linesToScroll; i++)
+                    scrollDownOneLine();
+                break;
+            }
+            case 'T':
+                if (mArgIndex == 0) {
+                    // "${CSI}${N}T" - Scroll down N lines (default = 1) (SD).
+                    // http://vt100.net/docs/vt510-rm/SD: "N is the number of lines to move the user window up in page
+                    // memory. N new lines appear at the top of the display. N old lines disappear at the bottom of the
+                    // display. You cannot pan past the top margin of the current page".
+                    final int linesToScrollArg = getArg0(1);
+                    final int linesBetweenTopAndBottomMargins = mBottomMargin - mTopMargin;
+                    final int linesToScroll = Math.min(linesBetweenTopAndBottomMargins, linesToScrollArg);
+                    mScreen.blockCopy(mLeftMargin, mTopMargin, mRightMargin - mLeftMargin, linesBetweenTopAndBottomMargins - linesToScroll, mLeftMargin, mTopMargin + linesToScroll);
+                    blockClear(mLeftMargin, mTopMargin, mRightMargin - mLeftMargin, linesToScroll);
+                } else {
+                    // "${CSI}${func};${startx};${starty};${firstrow};${lastrow}T" - initiate highlight mouse tracking.
+                    unimplementedSequence(b);
+                }
+                break;
+            case 'X': // "${CSI}${N}X" - Erase ${N:=1} character(s) (ECH). FIXME: Clears character attributes?
+                mAboutToAutoWrap = false;
+                mScreen.blockSet(mCursorCol, mCursorRow, Math.min(getArg0(1), mColumns - mCursorCol), 1, ' ', getStyle());
+                break;
+            case 'Z': // Cursor Backward Tabulation (CBT). Move the active position n tabs backward.
+                int numberOfTabs = getArg0(1);
+                int newCol = mLeftMargin;
+                for (int i = mCursorCol - 1; i >= 0; i--)
+                    if (mTabStop[i]) {
+                        if (--numberOfTabs == 0) {
+                            newCol = Math.max(i, mLeftMargin);
+                            break;
+                        }
+                    }
+                mCursorCol = newCol;
+                break;
+            case '?': // Esc [ ? -- start of a private parameter byte
+                continueSequence(ESC_CSI_QUESTIONMARK);
+                break;
+            case '>': // "Esc [ >" -- start of a private parameter byte
+                continueSequence(ESC_CSI_BIGGERTHAN);
+                break;
+            case '<': // "Esc [ <" -- start of a private parameter byte
+            case '=': // "Esc [ =" -- start of a private parameter byte
+                continueSequence(ESC_CSI_UNSUPPORTED_PARAMETER_BYTE);
+                break;
+            case '`': // Horizontal position absolute (HPA - http://www.vt100.net/docs/vt510-rm/HPA).
+                setCursorColRespectingOriginMode(getArg0(1) - 1);
+                break;
+            case 'b': // Repeat the preceding graphic character Ps times (REP).
+                if (mLastEmittedCodePoint == -1) break;
+                final int numRepeat = getArg0(1);
+                for (int i = 0; i < numRepeat; i++) emitCodePoint(mLastEmittedCodePoint);
+                break;
+            case 'c': // Primary Device Attributes (http://www.vt100.net/docs/vt510-rm/DA1) if argument is missing or zero.
+                // The important part that may still be used by some (tmux stores this value but does not currently use it)
+                // is the first response parameter identifying the terminal service class, where we send 64 for "vt420".
+                // This is followed by a list of attributes which is probably unused by applications. Send like xterm.
+                if (getArg0(0) == 0) mSession.write("\033[?64;1;2;6;9;15;18;21;22c");
+                break;
+            case 'd': // ESC [ Pn d - Vert Position Absolute
+                setCursorRow(Math.min(Math.max(1, getArg0(1)), mRows) - 1);
+                break;
+            case 'e': // Vertical Position Relative (VPR). From ISO-6429 (ECMA-48).
+                setCursorPosition(mCursorCol, mCursorRow + getArg0(1));
+                break;
+            // case 'f': "${CSI}${ROW};${COLUMN}f" - Horizontal and Vertical Position (HVP). Grouped with case 'H'.
+            case 'g': // Clear tab stop
+                switch (getArg0(0)) {
+                    case 0:
+                        mTabStop[mCursorCol] = false;
+                        break;
+                    case 3:
+                        for (int i = 0; i < mColumns; i++) {
+                            mTabStop[i] = false;
+                        }
+                        break;
+                    default:
+                        // Specified to have no effect.
+                        break;
+                }
+                break;
+            case 'h': // Set Mode
+                doSetMode(true);
+                break;
+            case 'l': // Reset Mode
+                doSetMode(false);
+                break;
+            case 'm': // Esc [ Pn m - character attributes. (can have up to 16 numerical arguments)
+                selectGraphicRendition();
+                break;
+            case 'n': // Esc [ Pn n - ECMA-48 Status Report Commands
+                // sendDeviceAttributes()
+                switch (getArg0(0)) {
+                    case 5: // Device status report (DSR):
+                        // Answer is ESC [ 0 n (Terminal OK).
+                        byte[] dsr = {(byte) 27, (byte) '[', (byte) '0', (byte) 'n'};
+                        mSession.write(dsr, 0, dsr.length);
+                        break;
+                    case 6: // Cursor position report (CPR):
+                        // Answer is ESC [ y ; x R, where x,y is
+                        // the cursor location.
+                        mSession.write(String.format(Locale.US, "\033[%d;%dR", mCursorRow + 1, mCursorCol + 1));
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case 'r': // "CSI${top};${bottom}r" - set top and bottom Margins (DECSTBM).
+            {
+                // https://vt100.net/docs/vt510-rm/DECSTBM.html
+                // The top margin defaults to 1, the bottom margin defaults to mRows.
+                // The escape sequence numbers top 1..23, but we number top 0..22.
+                // The escape sequence numbers bottom 2..24, and so do we (because we use a zero based numbering
+                // scheme, but we store the first line below the bottom-most scrolling line.
+                // As a result, we adjust the top line by -1, but we leave the bottom line alone.
+                // Also require that top + 2 <= bottom.
+                mTopMargin = Math.max(0, Math.min(getArg0(1) - 1, mRows - 2));
+                mBottomMargin = Math.max(mTopMargin + 2, Math.min(getArg1(mRows), mRows));
+
+                // DECSTBM moves the cursor to column 1, line 1 of the page respecting origin mode.
+                setCursorPosition(0, 0);
+            }
+            break;
+            case 's':
+                if (isDecsetInternalBitSet(DECSET_BIT_LEFTRIGHT_MARGIN_MODE)) {
+                    // Set left and right margins (DECSLRM - http://www.vt100.net/docs/vt510-rm/DECSLRM).
+                    mLeftMargin = Math.min(getArg0(1) - 1, mColumns - 2);
+                    mRightMargin = Math.max(mLeftMargin + 1, Math.min(getArg1(mColumns), mColumns));
+                    // DECSLRM moves the cursor to column 1, line 1 of the page.
+                    setCursorPosition(0, 0);
+                } else {
+                    // Save cursor (ANSI.SYS), available only when DECLRMM is disabled.
+                    saveCursor();
+                }
+                break;
+            case 't': // Window manipulation (from dtterm, as well as extensions)
+                switch (getArg0(0)) {
+                    case 11: // Report xterm window state. If the xterm window is open (non-iconified), it returns CSI 1 t .
+                        mSession.write("\033[1t");
+                        break;
+                    case 13: // Report xterm window position. Result is CSI 3 ; x ; y t
+                        mSession.write("\033[3;0;0t");
+                        break;
+                    case 14: // Report xterm window in pixels. Result is CSI 4 ; height ; width t
+                        mSession.write(String.format(Locale.US, "\033[4;%d;%dt", mRows * mCellHeightPixels, mColumns * mCellWidthPixels));
+                        break;
+                    case 16: // Report xterm character cell size in pixels. Result is CSI 6 ; height ; width t
+                        mSession.write(String.format(Locale.US, "\033[6;%d;%dt", mCellHeightPixels, mCellWidthPixels));
+                        break;
+                    case 18: // Report the size of the text area in characters. Result is CSI 8 ; height ; width t
+                        mSession.write(String.format(Locale.US, "\033[8;%d;%dt", mRows, mColumns));
+                        break;
+                    case 19: // Report the size of the screen in characters. Result is CSI 9 ; height ; width t
+                        // We report the same size as the view, since it's the view really isn't resizable from the shell.
+                        mSession.write(String.format(Locale.US, "\033[9;%d;%dt", mRows, mColumns));
+                        break;
+                    case 20: // Report xterm windows icon label. Result is OSC L label ST. Disabled due to security concerns:
+                        mSession.write("\033]LIconLabel\033\\");
+                        break;
+                    case 21: // Report xterm windows title. Result is OSC l label ST. Disabled due to security concerns:
+                        mSession.write("\033]l\033\\");
+                        break;
+                    case 22:
+                        // 22;0 -> Save xterm icon and window title on stack.
+                        // 22;1 -> Save xterm icon title on stack.
+                        // 22;2 -> Save xterm window title on stack.
+                        mTitleStack.push(mTitle);
+                        if (mTitleStack.size() > 20) {
+                            // Limit size
+                            mTitleStack.remove(0);
+                        }
+                        break;
+                    case 23: // Like 22 above but restore from stack.
+                        if (!mTitleStack.isEmpty()) setTitle(mTitleStack.pop());
+                        break;
+                    default:
+                        // Ignore window manipulation.
+                        break;
+                }
+                break;
+            case 'u': // Restore cursor (ANSI.SYS).
+                restoreCursor();
+                break;
+            case ' ':
+                continueSequence(ESC_CSI_ARGS_SPACE);
+                break;
+            default:
+                parseArg(b);
+                break;
+        }
+    }
+
+    /** Select Graphic Rendition (SGR) - see http://en.wikipedia.org/wiki/ANSI_escape_code#graphics. */
+    private void selectGraphicRendition() {
+        if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
+        for (int i = 0; i <= mArgIndex; i++) {
+            // Skip leading sub parameters:
+            if ((mArgsSubParamsBitSet & (1 << i)) != 0) {
+                continue;
+            }
+
+            int code = getArg(i, 0, false);
+            if (code < 0) {
+                if (mArgIndex > 0) {
+                    continue;
+                } else {
+                    code = 0;
+                }
+            }
+            if (code == 0) { // reset
+                mForeColor = TextStyle.COLOR_INDEX_FOREGROUND;
+                mBackColor = TextStyle.COLOR_INDEX_BACKGROUND;
+                mEffect = 0;
+            } else if (code == 1) {
+                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_BOLD;
+            } else if (code == 2) {
+                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_DIM;
+            } else if (code == 3) {
+                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_ITALIC;
+            } else if (code == 4) {
+                if (i + 1 <= mArgIndex && ((mArgsSubParamsBitSet & (1 << (i + 1))) != 0)) {
+                    // Sub parameter, see https://sw.kovidgoyal.net/kitty/underlines/
+                    i++;
+                    if (mArgs[i] == 0) {
+                        // No underline.
+                        mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+                    } else {
+                        // Different variations of underlines: https://sw.kovidgoyal.net/kitty/underlines/
+                        mEffect |= TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+                    }
+                } else {
+                    mEffect |= TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+                }
+            } else if (code == 5) {
+                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_BLINK;
+            } else if (code == 7) {
+                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
+            } else if (code == 8) {
+                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_INVISIBLE;
+            } else if (code == 9) {
+                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_STRIKETHROUGH;
+            } else if (code == 10) {
+                // Exit alt charset (TERM=linux) - ignore.
+            } else if (code == 11) {
+                // Enter alt charset (TERM=linux) - ignore.
+            } else if (code == 22) { // Normal color or intensity, neither bright, bold nor faint.
+                mEffect &= ~(TextStyle.CHARACTER_ATTRIBUTE_BOLD | TextStyle.CHARACTER_ATTRIBUTE_DIM);
+            } else if (code == 23) { // not italic, but rarely used as such; clears standout with TERM=screen
+                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_ITALIC;
+            } else if (code == 24) { // underline: none
+                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+            } else if (code == 25) { // blink: none
+                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_BLINK;
+            } else if (code == 27) { // image: positive
+                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
+            } else if (code == 28) {
+                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_INVISIBLE;
+            } else if (code == 29) {
+                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_STRIKETHROUGH;
+            } else if (code >= 30 && code <= 37) {
+                mForeColor = code - 30;
+            } else if (code == 38 || code == 48 || code == 58) {
+                // Extended set foreground(38)/background(48)/underline(58) color.
+                // This is followed by either "2;$R;$G;$B" to set a 24-bit color or
+                // "5;$INDEX" to set an indexed color.
+                if (i + 2 > mArgIndex) continue;
+                int firstArg = mArgs[i + 1];
+                if (firstArg == 2) {
+                    if (i + 4 > mArgIndex) {
+                        Logger.logWarn(mClient, LOG_TAG, "Too few CSI" + code + ";2 RGB arguments");
+                    } else {
+                        int red = getArg(i + 2, 0, false);
+                        int green = getArg(i + 3, 0, false);
+                        int blue = getArg(i + 4, 0, false);
+
+                        if (red < 0 || green < 0 || blue < 0 || red > 255 || green > 255 || blue > 255) {
+                            finishSequenceAndLogError("Invalid RGB: " + red + "," + green + "," + blue);
+                        } else {
+                            int argbColor = 0xff_00_00_00 | (red << 16) | (green << 8) | blue;
+                            switch (code) {
+                                case 38: mForeColor = argbColor; break;
+                                case 48: mBackColor = argbColor; break;
+                                case 58: mUnderlineColor = argbColor; break;
+                            }
+                        }
+                        i += 4; // "2;P_r;P_g;P_r"
+                    }
+                } else if (firstArg == 5) {
+                    int color = getArg(i + 2, 0, false);
+                    i += 2; // "5;P_s"
+                    if (color >= 0 && color < TextStyle.NUM_INDEXED_COLORS) {
+                        switch (code) {
+                            case 38: mForeColor = color; break;
+                            case 48: mBackColor = color; break;
+                            case 58: mUnderlineColor = color; break;
+                        }
+                    } else {
+                        if (LOG_ESCAPE_SEQUENCES) Logger.logWarn(mClient, LOG_TAG, "Invalid color index: " + color);
+                    }
+                } else {
+                    finishSequenceAndLogError("Invalid ISO-8613-3 SGR first argument: " + firstArg);
+                }
+            } else if (code == 39) { // Set default foreground color.
+                mForeColor = TextStyle.COLOR_INDEX_FOREGROUND;
+            } else if (code >= 40 && code <= 47) { // Set background color.
+                mBackColor = code - 40;
+            } else if (code == 49) { // Set default background color.
+                mBackColor = TextStyle.COLOR_INDEX_BACKGROUND;
+            } else if (code == 59) { // Set default underline color.
+                mUnderlineColor = TextStyle.COLOR_INDEX_FOREGROUND;
+            } else if (code >= 90 && code <= 97) { // Bright foreground colors (aixterm codes).
+                mForeColor = code - 90 + 8;
+            } else if (code >= 100 && code <= 107) { // Bright background color (aixterm codes).
+                mBackColor = code - 100 + 8;
+            } else {
+                if (LOG_ESCAPE_SEQUENCES)
+                    Logger.logWarn(mClient, LOG_TAG, String.format("SGR unknown code %d", code));
+            }
+        }
+    }
+
+    private void doOsc(int b) {
+        switch (b) {
+            case 7: // Bell.
+                doOscSetTextParameters("\007");
+                break;
+            case 27: // Escape.
+                continueSequence(ESC_OSC_ESC);
+                break;
+            default:
+                collectOSCArgs(b);
+                break;
+        }
+    }
+
+    private void doOscEsc(int b) {
+        switch (b) {
+            case '\\':
+                doOscSetTextParameters("\033\\");
+                break;
+            default:
+                // The ESC character was not followed by a \, so insert the ESC and
+                // the current character in arg buffer.
+                collectOSCArgs(27);
+                collectOSCArgs(b);
+                continueSequence(ESC_OSC);
+                break;
+        }
+    }
+
+    /** An Operating System Controls (OSC) Set Text Parameters. May come here from BEL or ST. */
+    private void doOscSetTextParameters(String bellOrStringTerminator) {
+        int value = -1;
+        String textParameter = "";
+        // Extract initial $value from initial "$value;..." string.
+        for (int mOSCArgTokenizerIndex = 0; mOSCArgTokenizerIndex < mOSCOrDeviceControlArgs.length(); mOSCArgTokenizerIndex++) {
+            char b = mOSCOrDeviceControlArgs.charAt(mOSCArgTokenizerIndex);
+            if (b == ';') {
+                textParameter = mOSCOrDeviceControlArgs.substring(mOSCArgTokenizerIndex + 1);
+                break;
+            } else if (b >= '0' && b <= '9') {
+                value = ((value < 0) ? 0 : value * 10) + (b - '0');
+            } else {
+                unknownSequence(b);
+                return;
+            }
+        }
+
+        switch (value) {
+            case 0: // Change icon name and window title to T.
+            case 1: // Change icon name to T.
+            case 2: // Change window title to T.
+                setTitle(textParameter);
+                break;
+            case 4:
+                // P s = 4 ; c ; spec → Change Color Number c to the color specified by spec. This can be a name or RGB
+                // specification as per XParseColor. Any number of c name pairs may be given. The color numbers correspond
+                // to the ANSI colors 0-7, their bright versions 8-15, and if supported, the remainder of the 88-color or
+                // 256-color table.
+                // If a "?" is given rather than a name or RGB specification, xterm replies with a control sequence of the
+                // same form which can be used to set the corresponding color. Because more than one pair of color number
+                // and specification can be given in one control sequence, xterm can make more than one reply.
+                int colorIndex = -1;
+                int parsingPairStart = -1;
+                for (int i = 0; ; i++) {
+                    boolean endOfInput = i == textParameter.length();
+                    char b = endOfInput ? ';' : textParameter.charAt(i);
+                    if (b == ';') {
+                        if (parsingPairStart < 0) {
+                            parsingPairStart = i + 1;
+                        } else {
+                            if (colorIndex < 0 || colorIndex > 255) {
+                                unknownSequence(b);
+                                return;
+                            } else {
+                                mColors.tryParseColor(colorIndex, textParameter.substring(parsingPairStart, i));
+                                mSession.onColorsChanged();
+                                colorIndex = -1;
+                                parsingPairStart = -1;
+                            }
+                        }
+                    } else if (parsingPairStart >= 0) {
+                        // We have passed a color index and are now going through color spec.
+                    } else if (parsingPairStart < 0 && (b >= '0' && b <= '9')) {
+                        colorIndex = ((colorIndex < 0) ? 0 : colorIndex * 10) + (b - '0');
+                    } else {
+                        unknownSequence(b);
+                        return;
+                    }
+                    if (endOfInput) break;
+                }
+                break;
+            case 10: // Set foreground color.
+            case 11: // Set background color.
+            case 12: // Set cursor color.
+                int specialIndex = TextStyle.COLOR_INDEX_FOREGROUND + (value - 10);
+                int lastSemiIndex = 0;
+                for (int charIndex = 0; ; charIndex++) {
+                    boolean endOfInput = charIndex == textParameter.length();
+                    if (endOfInput || textParameter.charAt(charIndex) == ';') {
+                        try {
+                            String colorSpec = textParameter.substring(lastSemiIndex, charIndex);
+                            if ("?".equals(colorSpec)) {
+                                // Report current color in the same format xterm and gnome-terminal does.
+                                int rgb = mColors.mCurrentColors[specialIndex];
+                                int r = (65535 * ((rgb & 0x00FF0000) >> 16)) / 255;
+                                int g = (65535 * ((rgb & 0x0000FF00) >> 8)) / 255;
+                                int b = (65535 * ((rgb & 0x000000FF))) / 255;
+                                mSession.write("\033]" + value + ";rgb:" + String.format(Locale.US, "%04x", r) + "/" + String.format(Locale.US, "%04x", g) + "/"
+                                    + String.format(Locale.US, "%04x", b) + bellOrStringTerminator);
+                            } else {
+                                mColors.tryParseColor(specialIndex, colorSpec);
+                                mSession.onColorsChanged();
+                            }
+                            specialIndex++;
+                            if (endOfInput || (specialIndex > TextStyle.COLOR_INDEX_CURSOR) || ++charIndex >= textParameter.length())
+                                break;
+                            lastSemiIndex = charIndex;
+                        } catch (NumberFormatException e) {
+                            // Ignore.
+                        }
+                    }
+                }
+                break;
+            case 52: // Manipulate Selection Data. Skip the optional first selection parameter(s).
+                int startIndex = textParameter.indexOf(";") + 1;
+                try {
+                    String clipboardText = new String(Base64.decode(textParameter.substring(startIndex), 0), StandardCharsets.UTF_8);
+                    mSession.onCopyTextToClipboard(clipboardText);
+                } catch (Exception e) {
+                    Logger.logError(mClient, LOG_TAG, "OSC Manipulate selection, invalid string '" + textParameter + "");
+                }
+                break;
+            case 104:
+                // "104;$c" → Reset Color Number $c. It is reset to the color specified by the corresponding X
+                // resource. Any number of c parameters may be given. These parameters correspond to the ANSI colors 0-7,
+                // their bright versions 8-15, and if supported, the remainder of the 88-color or 256-color table. If no
+                // parameters are given, the entire table will be reset.
+                if (textParameter.isEmpty()) {
+                    mColors.reset();
+                    mSession.onColorsChanged();
+                } else {
+                    int lastIndex = 0;
+                    for (int charIndex = 0; ; charIndex++) {
+                        boolean endOfInput = charIndex == textParameter.length();
+                        if (endOfInput || textParameter.charAt(charIndex) == ';') {
+                            try {
+                                int colorToReset = Integer.parseInt(textParameter.substring(lastIndex, charIndex));
+                                mColors.reset(colorToReset);
+                                mSession.onColorsChanged();
+                                if (endOfInput) break;
+                                charIndex++;
+                                lastIndex = charIndex;
+                            } catch (NumberFormatException e) {
+                                // Ignore.
+                            }
+                        }
+                    }
+                }
+                break;
+            case 110: // Reset foreground color.
+            case 111: // Reset background color.
+            case 112: // Reset cursor color.
+                mColors.reset(TextStyle.COLOR_INDEX_FOREGROUND + (value - 110));
+                mSession.onColorsChanged();
+                break;
+            case 119: // Reset highlight color.
+                break;
+            default:
+                unknownParameter(value);
+                break;
+        }
+        finishSequence();
+    }
+
+    private void blockClear(int sx, int sy, int w) {
+        blockClear(sx, sy, w, 1);
+    }
+
+    private void blockClear(int sx, int sy, int w, int h) {
+        mScreen.blockSet(sx, sy, w, h, ' ', getStyle());
+    }
+
+    private long getStyle() {
+        return TextStyle.encode(mForeColor, mBackColor, mEffect);
+    }
+
+    /** "CSI P_m h" for set or "CSI P_m l" for reset ANSI mode. */
+    private void doSetMode(boolean newValue) {
+        int modeBit = getArg0(0);
+        switch (modeBit) {
+            case 4: // Set="Insert Mode". Reset="Replace Mode". (IRM).
+                mInsertMode = newValue;
+                break;
+            case 20: // Normal Linefeed (LNM).
+                unknownParameter(modeBit);
+                // http://www.vt100.net/docs/vt510-rm/LNM
+                break;
+            case 34:
+                // Normal cursor visibility - when using TERM=screen, see
+                // http://www.gnu.org/software/screen/manual/html_node/Control-Sequences.html
+                break;
+            default:
+                unknownParameter(modeBit);
+                break;
+        }
+    }
+
+    /**
+     * NOTE: The parameters of this function respect the {@link #DECSET_BIT_ORIGIN_MODE}. Use
+     * {@link #setCursorRowCol(int, int)} for absolute pos.
+     */
+    private void setCursorPosition(int x, int y) {
+        boolean originMode = isDecsetInternalBitSet(DECSET_BIT_ORIGIN_MODE);
+        int effectiveTopMargin = originMode ? mTopMargin : 0;
+        int effectiveBottomMargin = originMode ? mBottomMargin : mRows;
+        int effectiveLeftMargin = originMode ? mLeftMargin : 0;
+        int effectiveRightMargin = originMode ? mRightMargin : mColumns;
+        int newRow = Math.max(effectiveTopMargin, Math.min(effectiveTopMargin + y, effectiveBottomMargin - 1));
+        int newCol = Math.max(effectiveLeftMargin, Math.min(effectiveLeftMargin + x, effectiveRightMargin - 1));
+        setCursorRowCol(newRow, newCol);
+    }
+
+    private void scrollDownOneLine() {
+        mScrollCounter++;
+        long currentStyle = getStyle();
+        if (mLeftMargin != 0 || mRightMargin != mColumns) {
+            // Horizontal margin: Do not put anything into scroll history, just non-margin part of screen up.
+            mScreen.blockCopy(mLeftMargin, mTopMargin + 1, mRightMargin - mLeftMargin, mBottomMargin - mTopMargin - 1, mLeftMargin, mTopMargin);
+            // .. and blank bottom row between margins:
+            mScreen.blockSet(mLeftMargin, mBottomMargin - 1, mRightMargin - mLeftMargin, 1, ' ', currentStyle);
+        } else {
+            mScreen.scrollDownOneLine(mTopMargin, mBottomMargin, currentStyle);
+        }
+    }
+
+    /**
+     * Process the next ASCII character of a parameter.
+     *
+     * <p>You must use the ; character to separate parameters and : to separate sub-parameters.
+     *
+     * <p>Parameter characters modify the action or interpretation of the sequence. Originally
+     * you can use up to 16 parameters per sequence, but following at least xterm and alacritty
+     * we use a common space for parameters and sub-parameters, allowing 32 in total.
+     *
+     * <p>All parameters are unsigned, positive decimal integers, with the most significant
+     * digit sent first. Any parameter greater than 9999 (decimal) is set to 9999
+     * (decimal). If you do not specify a value, a 0 value is assumed. A 0 value
+     * or omitted parameter indicates a default value for the sequence. For most
+     * sequences, the default value is 1.
+     *
+     * <p>References:
+     * <a href="https://vt100.net/docs/vt510-rm/chapter4.html#S4.3.3">VT510 Video Terminal Programmer Information: Control Sequences</a>
+     * <a href="https://github.com/alacritty/vte/issues/22">alacritty/vte: Implement colon separated CSI parameters</a>
+     * */
+    private void parseArg(int b) {
+        if (b >= '0' && b <= '9') {
+            if (mArgIndex < mArgs.length) {
+                int oldValue = mArgs[mArgIndex];
+                int thisDigit = b - '0';
+                int value;
+                if (oldValue >= 0) {
+                    value = oldValue * 10 + thisDigit;
+                } else {
+                    value = thisDigit;
+                }
+                if (value > 9999)
+                    value = 9999;
+                mArgs[mArgIndex] = value;
+            }
+            continueSequence(mEscapeState);
+        } else if (b == ';' || b == ':') {
+            if (mArgIndex + 1 < mArgs.length) {
+                mArgIndex++;
+                if (b == ':') {
+                    mArgsSubParamsBitSet |= 1 << mArgIndex;
+                }
+            } else {
+                logError("Too many parameters when in state: " + mEscapeState);
+            }
+            continueSequence(mEscapeState);
+        } else {
+            unknownSequence(b);
+        }
+    }
+
+    private int getArg0(int defaultValue) {
+        return getArg(0, defaultValue, true);
+    }
+
+    private int getArg1(int defaultValue) {
+        return getArg(1, defaultValue, true);
+    }
+
+    private int getArg(int index, int defaultValue, boolean treatZeroAsDefault) {
+        int result = mArgs[index];
+        if (result < 0 || (result == 0 && treatZeroAsDefault)) {
+            result = defaultValue;
+        }
+        return result;
+    }
+
+    private void collectOSCArgs(int b) {
+        if (mOSCOrDeviceControlArgs.length() < MAX_OSC_STRING_LENGTH) {
+            mOSCOrDeviceControlArgs.appendCodePoint(b);
+            continueSequence(mEscapeState);
+        } else {
+            unknownSequence(b);
+        }
+    }
+
+    private void unimplementedSequence(int b) {
+        logError("Unimplemented sequence char '" + (char) b + "' (U+" + String.format("%04x", b) + ")");
+        finishSequence();
+    }
+
+    private void unknownSequence(int b) {
+        logError("Unknown sequence char '" + (char) b + "' (numeric value=" + b + ")");
+        finishSequence();
+    }
+
+    private void unknownParameter(int parameter) {
+        logError("Unknown parameter: " + parameter);
+        finishSequence();
+    }
+
+    private void logError(String errorType) {
+        if (LOG_ESCAPE_SEQUENCES) {
+            StringBuilder buf = new StringBuilder();
+            buf.append(errorType);
+            buf.append(", escapeState=");
+            buf.append(mEscapeState);
+            boolean firstArg = true;
+            if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
+            for (int i = 0; i <= mArgIndex; i++) {
+                int value = mArgs[i];
+                if (value >= 0) {
+                    if (firstArg) {
+                        firstArg = false;
+                        buf.append(", args={");
+                    } else {
+                        buf.append(',');
+                    }
+                    buf.append(value);
+                }
+            }
+            if (!firstArg) buf.append('}');
+            finishSequenceAndLogError(buf.toString());
+        }
+    }
+
+    private void finishSequenceAndLogError(String error) {
+        if (LOG_ESCAPE_SEQUENCES) Logger.logWarn(mClient, LOG_TAG, error);
+        finishSequence();
+    }
+
+    private void finishSequence() {
+        mEscapeState = ESC_NONE;
+    }
+
+    /**
+     * Send a Unicode code point to the screen.
+     *
+     * @param codePoint The code point of the character to display
+     */
+    private void emitCodePoint(int codePoint) {
+        mLastEmittedCodePoint = codePoint;
+        if (mUseLineDrawingUsesG0 ? mUseLineDrawingG0 : mUseLineDrawingG1) {
+            // http://www.vt100.net/docs/vt102-ug/table5-15.html.
+            switch (codePoint) {
+                case '_':
+                    codePoint = ' '; // Blank.
+                    break;
+                case '`':
+                    codePoint = '◆'; // Diamond.
+                    break;
+                case '0':
+                    codePoint = '█'; // Solid block;
+                    break;
+                case 'a':
+                    codePoint = '▒'; // Checker board.
+                    break;
+                case 'b':
+                    codePoint = '␉'; // Horizontal tab.
+                    break;
+                case 'c':
+                    codePoint = '␌'; // Form feed.
+                    break;
+                case 'd':
+                    codePoint = '\r'; // Carriage return.
+                    break;
+                case 'e':
+                    codePoint = '␊'; // Linefeed.
+                    break;
+                case 'f':
+                    codePoint = '°'; // Degree.
+                    break;
+                case 'g':
+                    codePoint = '±'; // Plus-minus.
+                    break;
+                case 'h':
+                    codePoint = '\n'; // Newline.
+                    break;
+                case 'i':
+                    codePoint = '␋'; // Vertical tab.
+                    break;
+                case 'j':
+                    codePoint = '┘'; // Lower right corner.
+                    break;
+                case 'k':
+                    codePoint = '┐'; // Upper right corner.
+                    break;
+                case 'l':
+                    codePoint = '┌'; // Upper left corner.
+                    break;
+                case 'm':
+                    codePoint = '└'; // Left left corner.
+                    break;
+                case 'n':
+                    codePoint = '┼'; // Crossing lines.
+                    break;
+                case 'o':
+                    codePoint = '⎺'; // Horizontal line - scan 1.
+                    break;
+                case 'p':
+                    codePoint = '⎻'; // Horizontal line - scan 3.
+                    break;
+                case 'q':
+                    codePoint = '─'; // Horizontal line - scan 5.
+                    break;
+                case 'r':
+                    codePoint = '⎼'; // Horizontal line - scan 7.
+                    break;
+                case 's':
+                    codePoint = '⎽'; // Horizontal line - scan 9.
+                    break;
+                case 't':
+                    codePoint = '├'; // T facing rightwards.
+                    break;
+                case 'u':
+                    codePoint = '┤'; // T facing leftwards.
+                    break;
+                case 'v':
+                    codePoint = '┴'; // T facing upwards.
+                    break;
+                case 'w':
+                    codePoint = '┬'; // T facing downwards.
+                    break;
+                case 'x':
+                    codePoint = '│'; // Vertical line.
+                    break;
+                case 'y':
+                    codePoint = '≤'; // Less than or equal to.
+                    break;
+                case 'z':
+                    codePoint = '≥'; // Greater than or equal to.
+                    break;
+                case '{':
+                    codePoint = 'π'; // Pi.
+                    break;
+                case '|':
+                    codePoint = '≠'; // Not equal to.
+                    break;
+                case '}':
+                    codePoint = '£'; // UK pound.
+                    break;
+                case '~':
+                    codePoint = '·'; // Centered dot.
+                    break;
+            }
+        }
+
+        final boolean autoWrap = isDecsetInternalBitSet(DECSET_BIT_AUTOWRAP);
+        final int displayWidth = WcWidth.width(codePoint);
+        final boolean cursorInLastColumn = mCursorCol == mRightMargin - 1;
+
+        if (autoWrap) {
+            if (cursorInLastColumn && ((mAboutToAutoWrap && displayWidth == 1) || displayWidth == 2)) {
+                mScreen.setLineWrap(mCursorRow);
+                mCursorCol = mLeftMargin;
+                if (mCursorRow + 1 < mBottomMargin) {
+                    mCursorRow++;
+                } else {
+                    scrollDownOneLine();
+                }
+            }
+        } else if (cursorInLastColumn && displayWidth == 2) {
+            // The behaviour when a wide character is output with cursor in the last column when
+            // autowrap is disabled is not obvious - it's ignored here.
+            return;
+        }
+
+        if (mInsertMode && displayWidth > 0) {
+            // Move character to right one space.
+            int destCol = mCursorCol + displayWidth;
+            if (destCol < mRightMargin)
+                mScreen.blockCopy(mCursorCol, mCursorRow, mRightMargin - destCol, 1, destCol, mCursorRow);
+        }
+
+        int offsetDueToCombiningChar = ((displayWidth <= 0 && mCursorCol > 0 && !mAboutToAutoWrap) ? 1 : 0);
+        int column = mCursorCol - offsetDueToCombiningChar;
+
+        // Fix TerminalRow.setChar() ArrayIndexOutOfBoundsException index=-1 exception reported
+        // The offsetDueToCombiningChar would never be 1 if mCursorCol was 0 to get column/index=-1,
+        // so was mCursorCol changed after the offsetDueToCombiningChar conditional by another thread?
+        // TODO: Check if there are thread synchronization issues with mCursorCol and mCursorRow, possibly causing others bugs too.
+        if (column < 0) column = 0;
+        mScreen.setChar(column, mCursorRow, codePoint, getStyle());
+
+        if (autoWrap && displayWidth > 0)
+            mAboutToAutoWrap = (mCursorCol == mRightMargin - displayWidth);
+
+        mCursorCol = Math.min(mCursorCol + displayWidth, mRightMargin - 1);
+    }
+
+    private void setCursorRow(int row) {
+        mCursorRow = row;
+        mAboutToAutoWrap = false;
+    }
+
+    private void setCursorCol(int col) {
+        mCursorCol = col;
+        mAboutToAutoWrap = false;
+    }
+
+    /** Set the cursor mode, but limit it to margins if {@link #DECSET_BIT_ORIGIN_MODE} is enabled. */
+    private void setCursorColRespectingOriginMode(int col) {
+        setCursorPosition(col, mCursorRow);
+    }
+
+    /** TODO: Better name, distinguished from {@link #setCursorPosition(int, int)} by not regarding origin mode. */
+    private void setCursorRowCol(int row, int col) {
+        mCursorRow = Math.max(0, Math.min(row, mRows - 1));
+        mCursorCol = Math.max(0, Math.min(col, mColumns - 1));
+        mAboutToAutoWrap = false;
+    }
+
+    public int getScrollCounter() {
+        return mScrollCounter;
+    }
+
+    public void clearScrollCounter() {
+        mScrollCounter = 0;
+    }
+
+    public boolean isAutoScrollDisabled() {
+        return mAutoScrollDisabled;
+    }
+
+    public void toggleAutoScrollDisabled() {
+        mAutoScrollDisabled = !mAutoScrollDisabled;
+    }
+
+
+    /** Reset terminal state so user can interact with it regardless of present state. */
+    public void reset() {
+        setCursorStyle();
+        mArgIndex = 0;
+        mContinueSequence = false;
+        mEscapeState = ESC_NONE;
+        mInsertMode = false;
+        mTopMargin = mLeftMargin = 0;
+        mBottomMargin = mRows;
+        mRightMargin = mColumns;
+        mAboutToAutoWrap = false;
+        mForeColor = mSavedStateMain.mSavedForeColor = mSavedStateAlt.mSavedForeColor = TextStyle.COLOR_INDEX_FOREGROUND;
+        mBackColor = mSavedStateMain.mSavedBackColor = mSavedStateAlt.mSavedBackColor = TextStyle.COLOR_INDEX_BACKGROUND;
+        setDefaultTabStops();
+
+        mUseLineDrawingG0 = mUseLineDrawingG1 = false;
+        mUseLineDrawingUsesG0 = true;
+
+        mSavedStateMain.mSavedCursorRow = mSavedStateMain.mSavedCursorCol = mSavedStateMain.mSavedEffect = mSavedStateMain.mSavedDecFlags = 0;
+        mSavedStateAlt.mSavedCursorRow = mSavedStateAlt.mSavedCursorCol = mSavedStateAlt.mSavedEffect = mSavedStateAlt.mSavedDecFlags = 0;
+        mCurrentDecSetFlags = 0;
+        // Initial wrap-around is not accurate but makes terminal more useful, especially on a small screen:
+        setDecsetinternalBit(DECSET_BIT_AUTOWRAP, true);
+        setDecsetinternalBit(DECSET_BIT_CURSOR_ENABLED, true);
+        mSavedDecSetFlags = mSavedStateMain.mSavedDecFlags = mSavedStateAlt.mSavedDecFlags = mCurrentDecSetFlags;
+
+        // XXX: Should we set terminal driver back to IUTF8 with termios?
+        mUtf8Index = mUtf8ToFollow = 0;
+
+        mColors.reset();
+        mSession.onColorsChanged();
+    }
+
+    public String getSelectedText(int x1, int y1, int x2, int y2) {
+        return mScreen.getSelectedText(x1, y1, x2, y2);
+    }
+
+    /** Get the terminal session's title (null if not set). */
+    public String getTitle() {
+        return mTitle;
+    }
+
+    /** Change the terminal session's title. */
+    private void setTitle(String newTitle) {
+        String oldTitle = mTitle;
+        mTitle = newTitle;
+        if (!Objects.equals(oldTitle, newTitle)) {
+            mSession.titleChanged(oldTitle, newTitle);
+        }
+    }
+
+    /** If DECSET 2004 is set, prefix paste with "\033[200~" and suffix with "\033[201~". */
+    public void paste(String text) {
+        // First: Always remove escape key and C1 control characters [0x80,0x9F]:
+        text = text.replaceAll("(\u001B|[\u0080-\u009F])", "");
+        // Second: Replace all newlines (\n) or CRLF (\r\n) with carriage returns (\r).
+        text = text.replaceAll("\r?\n", "\r");
+
+        // Then: Implement bracketed paste mode if enabled:
+        boolean bracketed = isDecsetInternalBitSet(DECSET_BIT_BRACKETED_PASTE_MODE);
+        if (bracketed) mSession.write("\033[200~");
+        mSession.write(text);
+        if (bracketed) mSession.write("\033[201~");
+    }
+
+    /** http://www.vt100.net/docs/vt510-rm/DECSC */
+    static final class SavedScreenState {
+        /** Saved state of the cursor position, Used to implement the save/restore cursor position escape sequences. */
+        int mSavedCursorRow, mSavedCursorCol;
+        int mSavedEffect, mSavedForeColor, mSavedBackColor;
+        int mSavedDecFlags;
+        boolean mUseLineDrawingG0, mUseLineDrawingG1, mUseLineDrawingUsesG0 = true;
+    }
+
+    @Override
+    public String toString() {
+        return "TerminalEmulator[size=" + mScreen.mColumns + "x" + mScreen.mScreenRows + ", margins={" + mTopMargin + "," + mRightMargin + "," + mBottomMargin
+            + "," + mLeftMargin + "}]";
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalOutput.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalOutput.java
@@ -1,0 +1,32 @@
+package com.termux.terminal;
+
+import java.nio.charset.StandardCharsets;
+
+/** A client which receives callbacks from events triggered by feeding input to a {@link TerminalEmulator}. */
+public abstract class TerminalOutput {
+
+    /** Write a string using the UTF-8 encoding to the terminal client. */
+    public final void write(String data) {
+        if (data == null) return;
+        byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
+        write(bytes, 0, bytes.length);
+    }
+
+    /** Write bytes to the terminal client. */
+    public abstract void write(byte[] data, int offset, int count);
+
+    /** Notify the terminal client that the terminal title has changed. */
+    public abstract void titleChanged(String oldTitle, String newTitle);
+
+    /** Notify the terminal client that text should be copied to clipboard. */
+    public abstract void onCopyTextToClipboard(String text);
+
+    /** Notify the terminal client that text should be pasted from clipboard. */
+    public abstract void onPasteTextFromClipboard();
+
+    /** Notify the terminal client that a bell character (ASCII 7, bell, BEL, \a, ^G)) has been received. */
+    public abstract void onBell();
+
+    public abstract void onColorsChanged();
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalRow.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalRow.java
@@ -1,0 +1,283 @@
+package com.termux.terminal;
+
+import java.util.Arrays;
+
+/**
+ * A row in a terminal, composed of a fixed number of cells.
+ * <p>
+ * The text in the row is stored in a char[] array, {@link #mText}, for quick access during rendering.
+ */
+public final class TerminalRow {
+
+    private static final float SPARE_CAPACITY_FACTOR = 1.5f;
+
+    /**
+     * Max combining characters that can exist in a column, that are separate from the base character
+     * itself. Any additional combining characters will be ignored and not added to the column.
+     *
+     * There does not seem to be limit in unicode standard for max number of combination characters
+     * that can be combined but such characters are primarily under 10.
+     *
+     * "Section 3.6 Combination" of unicode standard contains combining characters info.
+     * - https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf
+     * - https://en.wikipedia.org/wiki/Combining_character#Unicode_ranges
+     * - https://stackoverflow.com/questions/71237212/what-is-the-maximum-number-of-unicode-combined-characters-that-may-be-needed-to
+     *
+     * UAX15-D3 Stream-Safe Text Format limits to max 30 combining characters.
+     * > The value of 30 is chosen to be significantly beyond what is required for any linguistic or technical usage.
+     * > While it would have been feasible to chose a smaller number, this value provides a very wide margin,
+     * > yet is well within the buffer size limits of practical implementations.
+     * - https://unicode.org/reports/tr15/#Stream_Safe_Text_Format
+     * - https://stackoverflow.com/a/11983435/14686958
+     *
+     * We choose the value 15 because it should be enough for terminal based applications and keep
+     * the memory usage low for a terminal row, won't affect performance or cause terminal to
+     * lag or hang, and will keep malicious applications from causing harm. The value can be
+     * increased if ever needed for legitimate applications.
+     */
+    private static final int MAX_COMBINING_CHARACTERS_PER_COLUMN = 15;
+
+    /** The number of columns in this terminal row. */
+    private final int mColumns;
+    /** The text filling this terminal row. */
+    public char[] mText;
+    /** The number of java chars used in {@link #mText}. */
+    private short mSpaceUsed;
+    /** If this row has been line wrapped due to text output at the end of line. */
+    boolean mLineWrap;
+    /** The style bits of each cell in the row. See {@link TextStyle}. */
+    final long[] mStyle;
+    /** If this row might contain chars with width != 1, used for deactivating fast path */
+    boolean mHasNonOneWidthOrSurrogateChars;
+
+    /** Construct a blank row (containing only whitespace, ' ') with a specified style. */
+    public TerminalRow(int columns, long style) {
+        mColumns = columns;
+        mText = new char[(int) (SPARE_CAPACITY_FACTOR * columns)];
+        mStyle = new long[columns];
+        clear(style);
+    }
+
+    /** NOTE: The sourceX2 is exclusive. */
+    public void copyInterval(TerminalRow line, int sourceX1, int sourceX2, int destinationX) {
+        mHasNonOneWidthOrSurrogateChars |= line.mHasNonOneWidthOrSurrogateChars;
+        final int x1 = line.findStartOfColumn(sourceX1);
+        final int x2 = line.findStartOfColumn(sourceX2);
+        boolean startingFromSecondHalfOfWideChar = (sourceX1 > 0 && line.wideDisplayCharacterStartingAt(sourceX1 - 1));
+        final char[] sourceChars = (this == line) ? Arrays.copyOf(line.mText, line.mText.length) : line.mText;
+        int latestNonCombiningWidth = 0;
+        for (int i = x1; i < x2; i++) {
+            char sourceChar = sourceChars[i];
+            int codePoint = Character.isHighSurrogate(sourceChar) ? Character.toCodePoint(sourceChar, sourceChars[++i]) : sourceChar;
+            if (startingFromSecondHalfOfWideChar) {
+                // Just treat copying second half of wide char as copying whitespace.
+                codePoint = ' ';
+                startingFromSecondHalfOfWideChar = false;
+            }
+            int w = WcWidth.width(codePoint);
+            if (w > 0) {
+                destinationX += latestNonCombiningWidth;
+                sourceX1 += latestNonCombiningWidth;
+                latestNonCombiningWidth = w;
+            }
+            setChar(destinationX, codePoint, line.getStyle(sourceX1));
+        }
+    }
+
+    public int getSpaceUsed() {
+        return mSpaceUsed;
+    }
+
+    /** Note that the column may end of second half of wide character. */
+    public int findStartOfColumn(int column) {
+        if (column == mColumns) return getSpaceUsed();
+
+        int currentColumn = 0;
+        int currentCharIndex = 0;
+        while (true) { // 0<2 1 < 2
+            int newCharIndex = currentCharIndex;
+            char c = mText[newCharIndex++]; // cci=1, cci=2
+            boolean isHigh = Character.isHighSurrogate(c);
+            int codePoint = isHigh ? Character.toCodePoint(c, mText[newCharIndex++]) : c;
+            int wcwidth = WcWidth.width(codePoint); // 1, 2
+            if (wcwidth > 0) {
+                currentColumn += wcwidth;
+                if (currentColumn == column) {
+                    while (newCharIndex < mSpaceUsed) {
+                        // Skip combining chars.
+                        if (Character.isHighSurrogate(mText[newCharIndex])) {
+                            if (WcWidth.width(Character.toCodePoint(mText[newCharIndex], mText[newCharIndex + 1])) <= 0) {
+                                newCharIndex += 2;
+                            } else {
+                                break;
+                            }
+                        } else if (WcWidth.width(mText[newCharIndex]) <= 0) {
+                            newCharIndex++;
+                        } else {
+                            break;
+                        }
+                    }
+                    return newCharIndex;
+                } else if (currentColumn > column) {
+                    // Wide column going past end.
+                    return currentCharIndex;
+                }
+            }
+            currentCharIndex = newCharIndex;
+        }
+    }
+
+    private boolean wideDisplayCharacterStartingAt(int column) {
+        for (int currentCharIndex = 0, currentColumn = 0; currentCharIndex < mSpaceUsed; ) {
+            char c = mText[currentCharIndex++];
+            int codePoint = Character.isHighSurrogate(c) ? Character.toCodePoint(c, mText[currentCharIndex++]) : c;
+            int wcwidth = WcWidth.width(codePoint);
+            if (wcwidth > 0) {
+                if (currentColumn == column && wcwidth == 2) return true;
+                currentColumn += wcwidth;
+                if (currentColumn > column) return false;
+            }
+        }
+        return false;
+    }
+
+    public void clear(long style) {
+        Arrays.fill(mText, ' ');
+        Arrays.fill(mStyle, style);
+        mSpaceUsed = (short) mColumns;
+        mHasNonOneWidthOrSurrogateChars = false;
+    }
+
+    // https://github.com/steven676/Android-Terminal-Emulator/commit/9a47042620bec87617f0b4f5d50568535668fe26
+    public void setChar(int columnToSet, int codePoint, long style) {
+        if (columnToSet  < 0 || columnToSet >= mStyle.length)
+            throw new IllegalArgumentException("TerminalRow.setChar(): columnToSet=" + columnToSet + ", codePoint=" + codePoint + ", style=" + style);
+
+        mStyle[columnToSet] = style;
+
+        final int newCodePointDisplayWidth = WcWidth.width(codePoint);
+
+        // Fast path when we don't have any chars with width != 1
+        if (!mHasNonOneWidthOrSurrogateChars) {
+            if (codePoint >= Character.MIN_SUPPLEMENTARY_CODE_POINT || newCodePointDisplayWidth != 1) {
+                mHasNonOneWidthOrSurrogateChars = true;
+            } else {
+                mText[columnToSet] = (char) codePoint;
+                return;
+            }
+        }
+
+        final boolean newIsCombining = newCodePointDisplayWidth <= 0;
+
+        boolean wasExtraColForWideChar = (columnToSet > 0) && wideDisplayCharacterStartingAt(columnToSet - 1);
+
+        if (newIsCombining) {
+            // When standing at second half of wide character and inserting combining:
+            if (wasExtraColForWideChar) columnToSet--;
+        } else {
+            // Check if we are overwriting the second half of a wide character starting at the previous column:
+            if (wasExtraColForWideChar) setChar(columnToSet - 1, ' ', style);
+            // Check if we are overwriting the first half of a wide character starting at the next column:
+            boolean overwritingWideCharInNextColumn = newCodePointDisplayWidth == 2 && wideDisplayCharacterStartingAt(columnToSet + 1);
+            if (overwritingWideCharInNextColumn) setChar(columnToSet + 1, ' ', style);
+        }
+
+        char[] text = mText;
+        final int oldStartOfColumnIndex = findStartOfColumn(columnToSet);
+        final int oldCodePointDisplayWidth = WcWidth.width(text, oldStartOfColumnIndex);
+
+        // Get the number of elements in the mText array this column uses now
+        int oldCharactersUsedForColumn;
+        if (columnToSet + oldCodePointDisplayWidth < mColumns) {
+            int oldEndOfColumnIndex = findStartOfColumn(columnToSet + oldCodePointDisplayWidth);
+            oldCharactersUsedForColumn = oldEndOfColumnIndex - oldStartOfColumnIndex;
+        } else {
+            // Last character.
+            oldCharactersUsedForColumn = mSpaceUsed - oldStartOfColumnIndex;
+        }
+
+        // If MAX_COMBINING_CHARACTERS_PER_COLUMN already exist in column, then ignore adding additional combining characters.
+        if (newIsCombining) {
+            int combiningCharsCount = WcWidth.zeroWidthCharsCount(mText, oldStartOfColumnIndex, oldStartOfColumnIndex + oldCharactersUsedForColumn);
+            if (combiningCharsCount >= MAX_COMBINING_CHARACTERS_PER_COLUMN)
+                return;
+        }
+
+        // Find how many chars this column will need
+        int newCharactersUsedForColumn = Character.charCount(codePoint);
+        if (newIsCombining) {
+            // Combining characters are added to the contents of the column instead of overwriting them, so that they
+            // modify the existing contents.
+            // FIXME: Unassigned characters also get width=0.
+            newCharactersUsedForColumn += oldCharactersUsedForColumn;
+        }
+
+        int oldNextColumnIndex = oldStartOfColumnIndex + oldCharactersUsedForColumn;
+        int newNextColumnIndex = oldStartOfColumnIndex + newCharactersUsedForColumn;
+
+        final int javaCharDifference = newCharactersUsedForColumn - oldCharactersUsedForColumn;
+        if (javaCharDifference > 0) {
+            // Shift the rest of the line right.
+            int oldCharactersAfterColumn = mSpaceUsed - oldNextColumnIndex;
+            if (mSpaceUsed + javaCharDifference > text.length) {
+                // We need to grow the array
+                char[] newText = new char[text.length + mColumns];
+                System.arraycopy(text, 0, newText, 0, oldNextColumnIndex);
+                System.arraycopy(text, oldNextColumnIndex, newText, newNextColumnIndex, oldCharactersAfterColumn);
+                mText = text = newText;
+            } else {
+                System.arraycopy(text, oldNextColumnIndex, text, newNextColumnIndex, oldCharactersAfterColumn);
+            }
+        } else if (javaCharDifference < 0) {
+            // Shift the rest of the line left.
+            System.arraycopy(text, oldNextColumnIndex, text, newNextColumnIndex, mSpaceUsed - oldNextColumnIndex);
+        }
+        mSpaceUsed += javaCharDifference;
+
+        // Store char. A combining character is stored at the end of the existing contents so that it modifies them:
+        //noinspection ResultOfMethodCallIgnored - since we already now how many java chars is used.
+        Character.toChars(codePoint, text, oldStartOfColumnIndex + (newIsCombining ? oldCharactersUsedForColumn : 0));
+
+        if (oldCodePointDisplayWidth == 2 && newCodePointDisplayWidth == 1) {
+            // Replace second half of wide char with a space. Which mean that we actually add a ' ' java character.
+            if (mSpaceUsed + 1 > text.length) {
+                char[] newText = new char[text.length + mColumns];
+                System.arraycopy(text, 0, newText, 0, newNextColumnIndex);
+                System.arraycopy(text, newNextColumnIndex, newText, newNextColumnIndex + 1, mSpaceUsed - newNextColumnIndex);
+                mText = text = newText;
+            } else {
+                System.arraycopy(text, newNextColumnIndex, text, newNextColumnIndex + 1, mSpaceUsed - newNextColumnIndex);
+            }
+            text[newNextColumnIndex] = ' ';
+
+            ++mSpaceUsed;
+        } else if (oldCodePointDisplayWidth == 1 && newCodePointDisplayWidth == 2) {
+            if (columnToSet == mColumns - 1) {
+                throw new IllegalArgumentException("Cannot put wide character in last column");
+            } else if (columnToSet == mColumns - 2) {
+                // Truncate the line to the second part of this wide char:
+                mSpaceUsed = (short) newNextColumnIndex;
+            } else {
+                // Overwrite the contents of the next column, which mean we actually remove java characters. Due to the
+                // check at the beginning of this method we know that we are not overwriting a wide char.
+                int newNextNextColumnIndex = newNextColumnIndex + (Character.isHighSurrogate(mText[newNextColumnIndex]) ? 2 : 1);
+                int nextLen = newNextNextColumnIndex - newNextColumnIndex;
+
+                // Shift the array leftwards.
+                System.arraycopy(text, newNextNextColumnIndex, text, newNextColumnIndex, mSpaceUsed - newNextNextColumnIndex);
+                mSpaceUsed -= nextLen;
+            }
+        }
+    }
+
+    boolean isBlank() {
+        for (int charIndex = 0, charLen = getSpaceUsed(); charIndex < charLen; charIndex++)
+            if (mText[charIndex] != ' ') return false;
+        return true;
+    }
+
+    public final long getStyle(int column) {
+        return mStyle[column];
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -1,0 +1,418 @@
+package com.termux.terminal;
+
+import android.annotation.SuppressLint;
+import android.os.Handler;
+import android.os.Message;
+import android.system.ErrnoException;
+import android.system.Os;
+import android.system.OsConstants;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class TerminalSession extends TerminalOutput {
+
+    private static final int MSG_NEW_INPUT = 1;
+    private static final int MSG_PROCESS_EXITED = 4;
+
+    public final String mHandle = UUID.randomUUID().toString();
+
+    TerminalEmulator mEmulator;
+
+    final ByteQueue mProcessToTerminalIOQueue = new ByteQueue(64 * 1024);
+    final ByteQueue mTerminalToProcessIOQueue = new ByteQueue(4096);
+    private final byte[] mUtf8InputBuffer = new byte[5];
+
+    TerminalSessionClient mClient;
+
+    int mShellPid;
+    int mShellExitStatus;
+
+    private int mTerminalFileDescriptor;
+
+    public String mSessionName;
+
+    final Handler mMainThreadHandler = new MainThreadHandler();
+
+    private final String mShellPath;
+    private final String mCwd;
+    private final String[] mArgs;
+    private final String[] mEnv;
+    private final Integer mTranscriptRows;
+
+    private final boolean mIsExternalIO;
+    private InputStream mExternalInputStream;
+    private OutputStream mExternalOutputStream;
+    private volatile boolean mRunning;
+    private OnResizeListener mResizeListener;
+
+    private static final String LOG_TAG = "TerminalSession";
+
+    public TerminalSession(String shellPath, String cwd, String[] args, String[] env, Integer transcriptRows, TerminalSessionClient client) {
+        this.mShellPath = shellPath;
+        this.mCwd = cwd;
+        this.mArgs = args;
+        this.mEnv = env;
+        this.mTranscriptRows = transcriptRows;
+        this.mClient = client;
+        this.mIsExternalIO = false;
+    }
+
+    /**
+     * Constructor for external I/O mode (e.g., SSH sessions).
+     * Skips JNI subprocess creation and uses provided streams directly.
+     */
+    public TerminalSession(InputStream inputStream, OutputStream outputStream, Integer transcriptRows, TerminalSessionClient client) {
+        this.mShellPath = null;
+        this.mCwd = null;
+        this.mArgs = null;
+        this.mEnv = null;
+        this.mTranscriptRows = transcriptRows;
+        this.mClient = client;
+        this.mIsExternalIO = true;
+        this.mExternalInputStream = inputStream;
+        this.mExternalOutputStream = outputStream;
+        this.mRunning = true;
+    }
+
+    public interface OnResizeListener {
+        void onResize(int columns, int rows);
+    }
+
+    public void setOnResizeListener(OnResizeListener listener) {
+        mResizeListener = listener;
+    }
+
+    public void updateTerminalSessionClient(TerminalSessionClient client) {
+        mClient = client;
+        if (mEmulator != null)
+            mEmulator.updateTerminalSessionClient(client);
+    }
+
+    public void updateSize(int columns, int rows, int cellWidthPixels, int cellHeightPixels) {
+        if (mEmulator == null) {
+            initializeEmulator(columns, rows, cellWidthPixels, cellHeightPixels);
+        } else {
+            if (!mIsExternalIO) {
+                JNI.setPtyWindowSize(mTerminalFileDescriptor, rows, columns, cellWidthPixels, cellHeightPixels);
+            }
+            mEmulator.resize(columns, rows, cellWidthPixels, cellHeightPixels);
+        }
+        if (mIsExternalIO && mResizeListener != null) {
+            mResizeListener.onResize(columns, rows);
+        }
+    }
+
+    public String getTitle() {
+        return (mEmulator == null) ? null : mEmulator.getTitle();
+    }
+
+    public void initializeEmulator(int columns, int rows, int cellWidthPixels, int cellHeightPixels) {
+        mEmulator = new TerminalEmulator(this, columns, rows, cellWidthPixels, cellHeightPixels, mTranscriptRows, mClient);
+
+        if (mIsExternalIO) {
+            initializeExternalIO();
+        } else {
+            initializeLocalProcess(columns, rows, cellWidthPixels, cellHeightPixels);
+        }
+    }
+
+    private void initializeExternalIO() {
+        new Thread("TermSessionInputReader[external]") {
+            @Override
+            public void run() {
+                android.util.Log.d("NectarTerminal", "InputReader thread started");
+                try {
+                    final byte[] buffer = new byte[4096];
+                    while (mRunning) {
+                        int read = mExternalInputStream.read(buffer);
+                        android.util.Log.d("NectarTerminal", "InputReader read: " + read + " bytes");
+                        if (read == -1) break;
+                        if (!mProcessToTerminalIOQueue.write(buffer, 0, read)) break;
+                        mMainThreadHandler.sendEmptyMessage(MSG_NEW_INPUT);
+                    }
+                } catch (Exception e) {
+                    android.util.Log.e("NectarTerminal", "InputReader exception", e);
+                }
+                android.util.Log.d("NectarTerminal", "InputReader thread exiting, posting PROCESS_EXITED");
+                mMainThreadHandler.sendMessage(mMainThreadHandler.obtainMessage(MSG_PROCESS_EXITED, 0));
+            }
+        }.start();
+
+        new Thread("TermSessionOutputWriter[external]") {
+            @Override
+            public void run() {
+                android.util.Log.d("NectarTerminal", "OutputWriter thread started");
+                final byte[] buffer = new byte[4096];
+                try {
+                    while (mRunning) {
+                        int bytesToWrite = mTerminalToProcessIOQueue.read(buffer, true);
+                        if (bytesToWrite == -1) break;
+                        StringBuilder hex = new StringBuilder();
+                        for (int i = 0; i < bytesToWrite; i++) hex.append(String.format("%02x ", buffer[i]));
+                        android.util.Log.d("NectarTerminal", "OutputWriter writing " + bytesToWrite + " bytes: " + hex.toString().trim());
+                        mExternalOutputStream.write(buffer, 0, bytesToWrite);
+                        mExternalOutputStream.flush();
+                    }
+                } catch (IOException e) {
+                    android.util.Log.e("NectarTerminal", "OutputWriter exception", e);
+                }
+                android.util.Log.d("NectarTerminal", "OutputWriter thread exiting");
+            }
+        }.start();
+    }
+
+    private void initializeLocalProcess(int columns, int rows, int cellWidthPixels, int cellHeightPixels) {
+        int[] processId = new int[1];
+        mTerminalFileDescriptor = JNI.createSubprocess(mShellPath, mCwd, mArgs, mEnv, processId, rows, columns, cellWidthPixels, cellHeightPixels);
+        mShellPid = processId[0];
+        mClient.setTerminalShellPid(this, mShellPid);
+
+        final FileDescriptor terminalFileDescriptorWrapped = wrapFileDescriptor(mTerminalFileDescriptor, mClient);
+
+        new Thread("TermSessionInputReader[pid=" + mShellPid + "]") {
+            @Override
+            public void run() {
+                try (InputStream termIn = new FileInputStream(terminalFileDescriptorWrapped)) {
+                    final byte[] buffer = new byte[4096];
+                    while (true) {
+                        int read = termIn.read(buffer);
+                        if (read == -1) return;
+                        if (!mProcessToTerminalIOQueue.write(buffer, 0, read)) return;
+                        mMainThreadHandler.sendEmptyMessage(MSG_NEW_INPUT);
+                    }
+                } catch (Exception e) {
+                    // Ignore, just shutting down.
+                }
+            }
+        }.start();
+
+        new Thread("TermSessionOutputWriter[pid=" + mShellPid + "]") {
+            @Override
+            public void run() {
+                final byte[] buffer = new byte[4096];
+                try (FileOutputStream termOut = new FileOutputStream(terminalFileDescriptorWrapped)) {
+                    while (true) {
+                        int bytesToWrite = mTerminalToProcessIOQueue.read(buffer, true);
+                        if (bytesToWrite == -1) return;
+                        termOut.write(buffer, 0, bytesToWrite);
+                    }
+                } catch (IOException e) {
+                    // Ignore.
+                }
+            }
+        }.start();
+
+        new Thread("TermSessionWaiter[pid=" + mShellPid + "]") {
+            @Override
+            public void run() {
+                int processExitCode = JNI.waitFor(mShellPid);
+                mMainThreadHandler.sendMessage(mMainThreadHandler.obtainMessage(MSG_PROCESS_EXITED, processExitCode));
+            }
+        }.start();
+    }
+
+    @Override
+    public void write(byte[] data, int offset, int count) {
+        if (mIsExternalIO) {
+            if (mRunning) mTerminalToProcessIOQueue.write(data, offset, count);
+        } else {
+            if (mShellPid > 0) mTerminalToProcessIOQueue.write(data, offset, count);
+        }
+    }
+
+    public void writeCodePoint(boolean prependEscape, int codePoint) {
+        if (codePoint > 1114111 || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+            throw new IllegalArgumentException("Invalid code point: " + codePoint);
+        }
+
+        int bufferPosition = 0;
+        if (prependEscape) mUtf8InputBuffer[bufferPosition++] = 27;
+
+        if (codePoint <= 0b1111111) {
+            mUtf8InputBuffer[bufferPosition++] = (byte) codePoint;
+        } else if (codePoint <= 0b11111111111) {
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b11000000 | (codePoint >> 6));
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b10000000 | (codePoint & 0b111111));
+        } else if (codePoint <= 0b1111111111111111) {
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b11100000 | (codePoint >> 12));
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b10000000 | ((codePoint >> 6) & 0b111111));
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b10000000 | (codePoint & 0b111111));
+        } else {
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b11110000 | (codePoint >> 18));
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b10000000 | ((codePoint >> 12) & 0b111111));
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b10000000 | ((codePoint >> 6) & 0b111111));
+            mUtf8InputBuffer[bufferPosition++] = (byte) (0b10000000 | (codePoint & 0b111111));
+        }
+        write(mUtf8InputBuffer, 0, bufferPosition);
+    }
+
+    public TerminalEmulator getEmulator() {
+        return mEmulator;
+    }
+
+    protected void notifyScreenUpdate() {
+        mClient.onTextChanged(this);
+    }
+
+    public void reset() {
+        mEmulator.reset();
+        notifyScreenUpdate();
+    }
+
+    public void finishIfRunning() {
+        if (mIsExternalIO) {
+            mRunning = false;
+            mTerminalToProcessIOQueue.close();
+            mProcessToTerminalIOQueue.close();
+            try {
+                mExternalInputStream.close();
+            } catch (IOException e) { /* ignore */ }
+            try {
+                mExternalOutputStream.close();
+            } catch (IOException e) { /* ignore */ }
+        } else if (isRunning()) {
+            try {
+                Os.kill(mShellPid, OsConstants.SIGKILL);
+            } catch (ErrnoException e) {
+                Logger.logWarn(mClient, LOG_TAG, "Failed sending SIGKILL: " + e.getMessage());
+            }
+        }
+    }
+
+    void cleanupResources(int exitStatus) {
+        synchronized (this) {
+            mShellPid = -1;
+            mShellExitStatus = exitStatus;
+            mRunning = false;
+        }
+
+        mTerminalToProcessIOQueue.close();
+        mProcessToTerminalIOQueue.close();
+        if (!mIsExternalIO) {
+            JNI.close(mTerminalFileDescriptor);
+        }
+    }
+
+    @Override
+    public void titleChanged(String oldTitle, String newTitle) {
+        mClient.onTitleChanged(this);
+    }
+
+    public synchronized boolean isRunning() {
+        if (mIsExternalIO) return mRunning;
+        return mShellPid != -1;
+    }
+
+    public synchronized int getExitStatus() {
+        return mShellExitStatus;
+    }
+
+    @Override
+    public void onCopyTextToClipboard(String text) {
+        mClient.onCopyTextToClipboard(this, text);
+    }
+
+    @Override
+    public void onPasteTextFromClipboard() {
+        mClient.onPasteTextFromClipboard(this);
+    }
+
+    @Override
+    public void onBell() {
+        mClient.onBell(this);
+    }
+
+    @Override
+    public void onColorsChanged() {
+        mClient.onColorsChanged(this);
+    }
+
+    public int getPid() {
+        return mShellPid;
+    }
+
+    public String getCwd() {
+        if (mIsExternalIO || mShellPid < 1) {
+            return null;
+        }
+        try {
+            final String cwdSymlink = String.format("/proc/%s/cwd/", mShellPid);
+            String outputPath = new File(cwdSymlink).getCanonicalPath();
+            String outputPathWithTrailingSlash = outputPath;
+            if (!outputPath.endsWith("/")) {
+                outputPathWithTrailingSlash += '/';
+            }
+            if (!cwdSymlink.equals(outputPathWithTrailingSlash)) {
+                return outputPath;
+            }
+        } catch (IOException | SecurityException e) {
+            Logger.logStackTraceWithMessage(mClient, LOG_TAG, "Error getting current directory", e);
+        }
+        return null;
+    }
+
+    private static FileDescriptor wrapFileDescriptor(int fileDescriptor, TerminalSessionClient client) {
+        FileDescriptor result = new FileDescriptor();
+        try {
+            Field descriptorField;
+            try {
+                descriptorField = FileDescriptor.class.getDeclaredField("descriptor");
+            } catch (NoSuchFieldException e) {
+                descriptorField = FileDescriptor.class.getDeclaredField("fd");
+            }
+            descriptorField.setAccessible(true);
+            descriptorField.set(result, fileDescriptor);
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
+            Logger.logStackTraceWithMessage(client, LOG_TAG, "Error accessing FileDescriptor#descriptor private field", e);
+            System.exit(1);
+        }
+        return result;
+    }
+
+    @SuppressLint("HandlerLeak")
+    class MainThreadHandler extends Handler {
+
+        final byte[] mReceiveBuffer = new byte[64 * 1024];
+
+        @Override
+        public void handleMessage(Message msg) {
+            int bytesRead = mProcessToTerminalIOQueue.read(mReceiveBuffer, false);
+            if (bytesRead > 0) {
+                mEmulator.append(mReceiveBuffer, bytesRead);
+                notifyScreenUpdate();
+            }
+
+            if (msg.what == MSG_PROCESS_EXITED) {
+                int exitCode = (Integer) msg.obj;
+                cleanupResources(exitCode);
+
+                String exitDescription = "\r\n[Session ended";
+                if (!mIsExternalIO) {
+                    if (exitCode > 0) {
+                        exitDescription += " (code " + exitCode + ")";
+                    } else if (exitCode < 0) {
+                        exitDescription += " (signal " + (-exitCode) + ")";
+                    }
+                }
+                exitDescription += " - press Enter]";
+
+                byte[] bytesToWrite = exitDescription.getBytes(StandardCharsets.UTF_8);
+                mEmulator.append(bytesToWrite, bytesToWrite.length);
+                notifyScreenUpdate();
+
+                mClient.onSessionFinished(TerminalSession.this);
+            }
+        }
+
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSessionClient.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSessionClient.java
@@ -1,0 +1,51 @@
+package com.termux.terminal;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * The interface for communication between {@link TerminalSession} and its client. It is used to
+ * send callbacks to the client when {@link TerminalSession} changes or for sending other
+ * back data to the client like logs.
+ */
+public interface TerminalSessionClient {
+
+    void onTextChanged(@NonNull TerminalSession changedSession);
+
+    void onTitleChanged(@NonNull TerminalSession changedSession);
+
+    void onSessionFinished(@NonNull TerminalSession finishedSession);
+
+    void onCopyTextToClipboard(@NonNull TerminalSession session, String text);
+
+    void onPasteTextFromClipboard(@Nullable TerminalSession session);
+
+    void onBell(@NonNull TerminalSession session);
+
+    void onColorsChanged(@NonNull TerminalSession session);
+
+    void onTerminalCursorStateChange(boolean state);
+
+    void setTerminalShellPid(@NonNull TerminalSession session, int pid);
+
+
+
+    Integer getTerminalCursorStyle();
+
+
+
+    void logError(String tag, String message);
+
+    void logWarn(String tag, String message);
+
+    void logInfo(String tag, String message);
+
+    void logDebug(String tag, String message);
+
+    void logVerbose(String tag, String message);
+
+    void logStackTraceWithMessage(String tag, String message, Exception e);
+
+    void logStackTrace(String tag, Exception e);
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TextStyle.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TextStyle.java
@@ -1,0 +1,90 @@
+package com.termux.terminal;
+
+/**
+ * <p>
+ * Encodes effects, foreground and background colors into a 64 bit long, which are stored for each cell in a terminal
+ * row in {@link TerminalRow#mStyle}.
+ * </p>
+ * <p>
+ * The bit layout is:
+ * </p>
+ * - 16 flags (11 currently used).
+ * - 24 for foreground color (only 9 first bits if a color index).
+ * - 24 for background color (only 9 first bits if a color index).
+ */
+public final class TextStyle {
+
+    public final static int CHARACTER_ATTRIBUTE_BOLD = 1;
+    public final static int CHARACTER_ATTRIBUTE_ITALIC = 1 << 1;
+    public final static int CHARACTER_ATTRIBUTE_UNDERLINE = 1 << 2;
+    public final static int CHARACTER_ATTRIBUTE_BLINK = 1 << 3;
+    public final static int CHARACTER_ATTRIBUTE_INVERSE = 1 << 4;
+    public final static int CHARACTER_ATTRIBUTE_INVISIBLE = 1 << 5;
+    public final static int CHARACTER_ATTRIBUTE_STRIKETHROUGH = 1 << 6;
+    /**
+     * The selective erase control functions (DECSED and DECSEL) can only erase characters defined as erasable.
+     * <p>
+     * This bit is set if DECSCA (Select Character Protection Attribute) has been used to define the characters that
+     * come after it as erasable from the screen.
+     * </p>
+     */
+    public final static int CHARACTER_ATTRIBUTE_PROTECTED = 1 << 7;
+    /** Dim colors. Also known as faint or half intensity. */
+    public final static int CHARACTER_ATTRIBUTE_DIM = 1 << 8;
+    /** If true (24-bit) color is used for the cell for foreground. */
+    private final static int CHARACTER_ATTRIBUTE_TRUECOLOR_FOREGROUND = 1 << 9;
+    /** If true (24-bit) color is used for the cell for foreground. */
+    private final static int CHARACTER_ATTRIBUTE_TRUECOLOR_BACKGROUND= 1 << 10;
+
+    public final static int COLOR_INDEX_FOREGROUND = 256;
+    public final static int COLOR_INDEX_BACKGROUND = 257;
+    public final static int COLOR_INDEX_CURSOR = 258;
+
+    /** The 256 standard color entries and the three special (foreground, background and cursor) ones. */
+    public final static int NUM_INDEXED_COLORS = 259;
+
+    /** Normal foreground and background colors and no effects. */
+    final static long NORMAL = encode(COLOR_INDEX_FOREGROUND, COLOR_INDEX_BACKGROUND, 0);
+
+    static long encode(int foreColor, int backColor, int effect) {
+        long result = effect & 0b111111111;
+        if ((0xff000000 & foreColor) == 0xff000000) {
+            // 24-bit color.
+            result |= CHARACTER_ATTRIBUTE_TRUECOLOR_FOREGROUND | ((foreColor & 0x00ffffffL) << 40L);
+        } else {
+            // Indexed color.
+            result |= (foreColor & 0b111111111L) << 40;
+        }
+        if ((0xff000000 & backColor) == 0xff000000) {
+            // 24-bit color.
+            result |= CHARACTER_ATTRIBUTE_TRUECOLOR_BACKGROUND | ((backColor & 0x00ffffffL) << 16L);
+        } else {
+            // Indexed color.
+            result |= (backColor & 0b111111111L) << 16L;
+        }
+
+        return result;
+    }
+
+    public static int decodeForeColor(long style) {
+        if ((style & CHARACTER_ATTRIBUTE_TRUECOLOR_FOREGROUND) == 0) {
+            return (int) ((style >>> 40) & 0b111111111L);
+        } else {
+            return 0xff000000 | (int) ((style >>> 40) & 0x00ffffffL);
+        }
+
+    }
+
+    public static int decodeBackColor(long style) {
+        if ((style & CHARACTER_ATTRIBUTE_TRUECOLOR_BACKGROUND) == 0) {
+            return (int) ((style >>> 16) & 0b111111111L);
+        } else {
+            return 0xff000000 | (int) ((style >>> 16) & 0x00ffffffL);
+        }
+    }
+
+    public static int decodeEffect(long style) {
+        return (int) (style & 0b11111111111);
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/WcWidth.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/WcWidth.java
@@ -1,0 +1,566 @@
+package com.termux.terminal;
+
+/**
+ * Implementation of wcwidth(3) for Unicode 15.
+ *
+ * Implementation from https://github.com/jquast/wcwidth but we return 0 for unprintable characters.
+ *
+ * IMPORTANT:
+ * Must be kept in sync with the following:
+ * https://github.com/termux/wcwidth
+ * https://github.com/termux/libandroid-support
+ * https://github.com/termux/termux-packages/tree/master/packages/libandroid-support
+ */
+public final class WcWidth {
+
+    // From https://github.com/jquast/wcwidth/blob/master/wcwidth/table_zero.py
+    // from https://github.com/jquast/wcwidth/pull/64
+    // at commit 1b9b6585b0080ea5cb88dc9815796505724793fe (2022-12-16):
+    private static final int[][] ZERO_WIDTH = {
+        {0x00300, 0x0036f},  // Combining Grave Accent  ..Combining Latin Small Le
+        {0x00483, 0x00489},  // Combining Cyrillic Titlo..Combining Cyrillic Milli
+        {0x00591, 0x005bd},  // Hebrew Accent Etnahta   ..Hebrew Point Meteg
+        {0x005bf, 0x005bf},  // Hebrew Point Rafe       ..Hebrew Point Rafe
+        {0x005c1, 0x005c2},  // Hebrew Point Shin Dot   ..Hebrew Point Sin Dot
+        {0x005c4, 0x005c5},  // Hebrew Mark Upper Dot   ..Hebrew Mark Lower Dot
+        {0x005c7, 0x005c7},  // Hebrew Point Qamats Qata..Hebrew Point Qamats Qata
+        {0x00610, 0x0061a},  // Arabic Sign Sallallahou ..Arabic Small Kasra
+        {0x0064b, 0x0065f},  // Arabic Fathatan         ..Arabic Wavy Hamza Below
+        {0x00670, 0x00670},  // Arabic Letter Superscrip..Arabic Letter Superscrip
+        {0x006d6, 0x006dc},  // Arabic Small High Ligatu..Arabic Small High Seen
+        {0x006df, 0x006e4},  // Arabic Small High Rounde..Arabic Small High Madda
+        {0x006e7, 0x006e8},  // Arabic Small High Yeh   ..Arabic Small High Noon
+        {0x006ea, 0x006ed},  // Arabic Empty Centre Low ..Arabic Small Low Meem
+        {0x00711, 0x00711},  // Syriac Letter Superscrip..Syriac Letter Superscrip
+        {0x00730, 0x0074a},  // Syriac Pthaha Above     ..Syriac Barrekh
+        {0x007a6, 0x007b0},  // Thaana Abafili          ..Thaana Sukun
+        {0x007eb, 0x007f3},  // Nko Combining Short High..Nko Combining Double Dot
+        {0x007fd, 0x007fd},  // Nko Dantayalan          ..Nko Dantayalan
+        {0x00816, 0x00819},  // Samaritan Mark In       ..Samaritan Mark Dagesh
+        {0x0081b, 0x00823},  // Samaritan Mark Epentheti..Samaritan Vowel Sign A
+        {0x00825, 0x00827},  // Samaritan Vowel Sign Sho..Samaritan Vowel Sign U
+        {0x00829, 0x0082d},  // Samaritan Vowel Sign Lon..Samaritan Mark Nequdaa
+        {0x00859, 0x0085b},  // Mandaic Affrication Mark..Mandaic Gemination Mark
+        {0x00898, 0x0089f},  // Arabic Small High Word A..Arabic Half Madda Over M
+        {0x008ca, 0x008e1},  // Arabic Small High Farsi ..Arabic Small High Sign S
+        {0x008e3, 0x00902},  // Arabic Turned Damma Belo..Devanagari Sign Anusvara
+        {0x0093a, 0x0093a},  // Devanagari Vowel Sign Oe..Devanagari Vowel Sign Oe
+        {0x0093c, 0x0093c},  // Devanagari Sign Nukta   ..Devanagari Sign Nukta
+        {0x00941, 0x00948},  // Devanagari Vowel Sign U ..Devanagari Vowel Sign Ai
+        {0x0094d, 0x0094d},  // Devanagari Sign Virama  ..Devanagari Sign Virama
+        {0x00951, 0x00957},  // Devanagari Stress Sign U..Devanagari Vowel Sign Uu
+        {0x00962, 0x00963},  // Devanagari Vowel Sign Vo..Devanagari Vowel Sign Vo
+        {0x00981, 0x00981},  // Bengali Sign Candrabindu..Bengali Sign Candrabindu
+        {0x009bc, 0x009bc},  // Bengali Sign Nukta      ..Bengali Sign Nukta
+        {0x009c1, 0x009c4},  // Bengali Vowel Sign U    ..Bengali Vowel Sign Vocal
+        {0x009cd, 0x009cd},  // Bengali Sign Virama     ..Bengali Sign Virama
+        {0x009e2, 0x009e3},  // Bengali Vowel Sign Vocal..Bengali Vowel Sign Vocal
+        {0x009fe, 0x009fe},  // Bengali Sandhi Mark     ..Bengali Sandhi Mark
+        {0x00a01, 0x00a02},  // Gurmukhi Sign Adak Bindi..Gurmukhi Sign Bindi
+        {0x00a3c, 0x00a3c},  // Gurmukhi Sign Nukta     ..Gurmukhi Sign Nukta
+        {0x00a41, 0x00a42},  // Gurmukhi Vowel Sign U   ..Gurmukhi Vowel Sign Uu
+        {0x00a47, 0x00a48},  // Gurmukhi Vowel Sign Ee  ..Gurmukhi Vowel Sign Ai
+        {0x00a4b, 0x00a4d},  // Gurmukhi Vowel Sign Oo  ..Gurmukhi Sign Virama
+        {0x00a51, 0x00a51},  // Gurmukhi Sign Udaat     ..Gurmukhi Sign Udaat
+        {0x00a70, 0x00a71},  // Gurmukhi Tippi          ..Gurmukhi Addak
+        {0x00a75, 0x00a75},  // Gurmukhi Sign Yakash    ..Gurmukhi Sign Yakash
+        {0x00a81, 0x00a82},  // Gujarati Sign Candrabind..Gujarati Sign Anusvara
+        {0x00abc, 0x00abc},  // Gujarati Sign Nukta     ..Gujarati Sign Nukta
+        {0x00ac1, 0x00ac5},  // Gujarati Vowel Sign U   ..Gujarati Vowel Sign Cand
+        {0x00ac7, 0x00ac8},  // Gujarati Vowel Sign E   ..Gujarati Vowel Sign Ai
+        {0x00acd, 0x00acd},  // Gujarati Sign Virama    ..Gujarati Sign Virama
+        {0x00ae2, 0x00ae3},  // Gujarati Vowel Sign Voca..Gujarati Vowel Sign Voca
+        {0x00afa, 0x00aff},  // Gujarati Sign Sukun     ..Gujarati Sign Two-circle
+        {0x00b01, 0x00b01},  // Oriya Sign Candrabindu  ..Oriya Sign Candrabindu
+        {0x00b3c, 0x00b3c},  // Oriya Sign Nukta        ..Oriya Sign Nukta
+        {0x00b3f, 0x00b3f},  // Oriya Vowel Sign I      ..Oriya Vowel Sign I
+        {0x00b41, 0x00b44},  // Oriya Vowel Sign U      ..Oriya Vowel Sign Vocalic
+        {0x00b4d, 0x00b4d},  // Oriya Sign Virama       ..Oriya Sign Virama
+        {0x00b55, 0x00b56},  // Oriya Sign Overline     ..Oriya Ai Length Mark
+        {0x00b62, 0x00b63},  // Oriya Vowel Sign Vocalic..Oriya Vowel Sign Vocalic
+        {0x00b82, 0x00b82},  // Tamil Sign Anusvara     ..Tamil Sign Anusvara
+        {0x00bc0, 0x00bc0},  // Tamil Vowel Sign Ii     ..Tamil Vowel Sign Ii
+        {0x00bcd, 0x00bcd},  // Tamil Sign Virama       ..Tamil Sign Virama
+        {0x00c00, 0x00c00},  // Telugu Sign Combining Ca..Telugu Sign Combining Ca
+        {0x00c04, 0x00c04},  // Telugu Sign Combining An..Telugu Sign Combining An
+        {0x00c3c, 0x00c3c},  // Telugu Sign Nukta       ..Telugu Sign Nukta
+        {0x00c3e, 0x00c40},  // Telugu Vowel Sign Aa    ..Telugu Vowel Sign Ii
+        {0x00c46, 0x00c48},  // Telugu Vowel Sign E     ..Telugu Vowel Sign Ai
+        {0x00c4a, 0x00c4d},  // Telugu Vowel Sign O     ..Telugu Sign Virama
+        {0x00c55, 0x00c56},  // Telugu Length Mark      ..Telugu Ai Length Mark
+        {0x00c62, 0x00c63},  // Telugu Vowel Sign Vocali..Telugu Vowel Sign Vocali
+        {0x00c81, 0x00c81},  // Kannada Sign Candrabindu..Kannada Sign Candrabindu
+        {0x00cbc, 0x00cbc},  // Kannada Sign Nukta      ..Kannada Sign Nukta
+        {0x00cbf, 0x00cbf},  // Kannada Vowel Sign I    ..Kannada Vowel Sign I
+        {0x00cc6, 0x00cc6},  // Kannada Vowel Sign E    ..Kannada Vowel Sign E
+        {0x00ccc, 0x00ccd},  // Kannada Vowel Sign Au   ..Kannada Sign Virama
+        {0x00ce2, 0x00ce3},  // Kannada Vowel Sign Vocal..Kannada Vowel Sign Vocal
+        {0x00d00, 0x00d01},  // Malayalam Sign Combining..Malayalam Sign Candrabin
+        {0x00d3b, 0x00d3c},  // Malayalam Sign Vertical ..Malayalam Sign Circular
+        {0x00d41, 0x00d44},  // Malayalam Vowel Sign U  ..Malayalam Vowel Sign Voc
+        {0x00d4d, 0x00d4d},  // Malayalam Sign Virama   ..Malayalam Sign Virama
+        {0x00d62, 0x00d63},  // Malayalam Vowel Sign Voc..Malayalam Vowel Sign Voc
+        {0x00d81, 0x00d81},  // Sinhala Sign Candrabindu..Sinhala Sign Candrabindu
+        {0x00dca, 0x00dca},  // Sinhala Sign Al-lakuna  ..Sinhala Sign Al-lakuna
+        {0x00dd2, 0x00dd4},  // Sinhala Vowel Sign Ketti..Sinhala Vowel Sign Ketti
+        {0x00dd6, 0x00dd6},  // Sinhala Vowel Sign Diga ..Sinhala Vowel Sign Diga
+        {0x00e31, 0x00e31},  // Thai Character Mai Han-a..Thai Character Mai Han-a
+        {0x00e34, 0x00e3a},  // Thai Character Sara I   ..Thai Character Phinthu
+        {0x00e47, 0x00e4e},  // Thai Character Maitaikhu..Thai Character Yamakkan
+        {0x00eb1, 0x00eb1},  // Lao Vowel Sign Mai Kan  ..Lao Vowel Sign Mai Kan
+        {0x00eb4, 0x00ebc},  // Lao Vowel Sign I        ..Lao Semivowel Sign Lo
+        {0x00ec8, 0x00ece},  // Lao Tone Mai Ek         ..(nil)
+        {0x00f18, 0x00f19},  // Tibetan Astrological Sig..Tibetan Astrological Sig
+        {0x00f35, 0x00f35},  // Tibetan Mark Ngas Bzung ..Tibetan Mark Ngas Bzung
+        {0x00f37, 0x00f37},  // Tibetan Mark Ngas Bzung ..Tibetan Mark Ngas Bzung
+        {0x00f39, 0x00f39},  // Tibetan Mark Tsa -phru  ..Tibetan Mark Tsa -phru
+        {0x00f71, 0x00f7e},  // Tibetan Vowel Sign Aa   ..Tibetan Sign Rjes Su Nga
+        {0x00f80, 0x00f84},  // Tibetan Vowel Sign Rever..Tibetan Mark Halanta
+        {0x00f86, 0x00f87},  // Tibetan Sign Lci Rtags  ..Tibetan Sign Yang Rtags
+        {0x00f8d, 0x00f97},  // Tibetan Subjoined Sign L..Tibetan Subjoined Letter
+        {0x00f99, 0x00fbc},  // Tibetan Subjoined Letter..Tibetan Subjoined Letter
+        {0x00fc6, 0x00fc6},  // Tibetan Symbol Padma Gda..Tibetan Symbol Padma Gda
+        {0x0102d, 0x01030},  // Myanmar Vowel Sign I    ..Myanmar Vowel Sign Uu
+        {0x01032, 0x01037},  // Myanmar Vowel Sign Ai   ..Myanmar Sign Dot Below
+        {0x01039, 0x0103a},  // Myanmar Sign Virama     ..Myanmar Sign Asat
+        {0x0103d, 0x0103e},  // Myanmar Consonant Sign M..Myanmar Consonant Sign M
+        {0x01058, 0x01059},  // Myanmar Vowel Sign Vocal..Myanmar Vowel Sign Vocal
+        {0x0105e, 0x01060},  // Myanmar Consonant Sign M..Myanmar Consonant Sign M
+        {0x01071, 0x01074},  // Myanmar Vowel Sign Geba ..Myanmar Vowel Sign Kayah
+        {0x01082, 0x01082},  // Myanmar Consonant Sign S..Myanmar Consonant Sign S
+        {0x01085, 0x01086},  // Myanmar Vowel Sign Shan ..Myanmar Vowel Sign Shan
+        {0x0108d, 0x0108d},  // Myanmar Sign Shan Counci..Myanmar Sign Shan Counci
+        {0x0109d, 0x0109d},  // Myanmar Vowel Sign Aiton..Myanmar Vowel Sign Aiton
+        {0x0135d, 0x0135f},  // Ethiopic Combining Gemin..Ethiopic Combining Gemin
+        {0x01712, 0x01714},  // Tagalog Vowel Sign I    ..Tagalog Sign Virama
+        {0x01732, 0x01733},  // Hanunoo Vowel Sign I    ..Hanunoo Vowel Sign U
+        {0x01752, 0x01753},  // Buhid Vowel Sign I      ..Buhid Vowel Sign U
+        {0x01772, 0x01773},  // Tagbanwa Vowel Sign I   ..Tagbanwa Vowel Sign U
+        {0x017b4, 0x017b5},  // Khmer Vowel Inherent Aq ..Khmer Vowel Inherent Aa
+        {0x017b7, 0x017bd},  // Khmer Vowel Sign I      ..Khmer Vowel Sign Ua
+        {0x017c6, 0x017c6},  // Khmer Sign Nikahit      ..Khmer Sign Nikahit
+        {0x017c9, 0x017d3},  // Khmer Sign Muusikatoan  ..Khmer Sign Bathamasat
+        {0x017dd, 0x017dd},  // Khmer Sign Atthacan     ..Khmer Sign Atthacan
+        {0x0180b, 0x0180d},  // Mongolian Free Variation..Mongolian Free Variation
+        {0x0180f, 0x0180f},  // Mongolian Free Variation..Mongolian Free Variation
+        {0x01885, 0x01886},  // Mongolian Letter Ali Gal..Mongolian Letter Ali Gal
+        {0x018a9, 0x018a9},  // Mongolian Letter Ali Gal..Mongolian Letter Ali Gal
+        {0x01920, 0x01922},  // Limbu Vowel Sign A      ..Limbu Vowel Sign U
+        {0x01927, 0x01928},  // Limbu Vowel Sign E      ..Limbu Vowel Sign O
+        {0x01932, 0x01932},  // Limbu Small Letter Anusv..Limbu Small Letter Anusv
+        {0x01939, 0x0193b},  // Limbu Sign Mukphreng    ..Limbu Sign Sa-i
+        {0x01a17, 0x01a18},  // Buginese Vowel Sign I   ..Buginese Vowel Sign U
+        {0x01a1b, 0x01a1b},  // Buginese Vowel Sign Ae  ..Buginese Vowel Sign Ae
+        {0x01a56, 0x01a56},  // Tai Tham Consonant Sign ..Tai Tham Consonant Sign
+        {0x01a58, 0x01a5e},  // Tai Tham Sign Mai Kang L..Tai Tham Consonant Sign
+        {0x01a60, 0x01a60},  // Tai Tham Sign Sakot     ..Tai Tham Sign Sakot
+        {0x01a62, 0x01a62},  // Tai Tham Vowel Sign Mai ..Tai Tham Vowel Sign Mai
+        {0x01a65, 0x01a6c},  // Tai Tham Vowel Sign I   ..Tai Tham Vowel Sign Oa B
+        {0x01a73, 0x01a7c},  // Tai Tham Vowel Sign Oa A..Tai Tham Sign Khuen-lue
+        {0x01a7f, 0x01a7f},  // Tai Tham Combining Crypt..Tai Tham Combining Crypt
+        {0x01ab0, 0x01ace},  // Combining Doubled Circum..Combining Latin Small Le
+        {0x01b00, 0x01b03},  // Balinese Sign Ulu Ricem ..Balinese Sign Surang
+        {0x01b34, 0x01b34},  // Balinese Sign Rerekan   ..Balinese Sign Rerekan
+        {0x01b36, 0x01b3a},  // Balinese Vowel Sign Ulu ..Balinese Vowel Sign Ra R
+        {0x01b3c, 0x01b3c},  // Balinese Vowel Sign La L..Balinese Vowel Sign La L
+        {0x01b42, 0x01b42},  // Balinese Vowel Sign Pepe..Balinese Vowel Sign Pepe
+        {0x01b6b, 0x01b73},  // Balinese Musical Symbol ..Balinese Musical Symbol
+        {0x01b80, 0x01b81},  // Sundanese Sign Panyecek ..Sundanese Sign Panglayar
+        {0x01ba2, 0x01ba5},  // Sundanese Consonant Sign..Sundanese Vowel Sign Pan
+        {0x01ba8, 0x01ba9},  // Sundanese Vowel Sign Pam..Sundanese Vowel Sign Pan
+        {0x01bab, 0x01bad},  // Sundanese Sign Virama   ..Sundanese Consonant Sign
+        {0x01be6, 0x01be6},  // Batak Sign Tompi        ..Batak Sign Tompi
+        {0x01be8, 0x01be9},  // Batak Vowel Sign Pakpak ..Batak Vowel Sign Ee
+        {0x01bed, 0x01bed},  // Batak Vowel Sign Karo O ..Batak Vowel Sign Karo O
+        {0x01bef, 0x01bf1},  // Batak Vowel Sign U For S..Batak Consonant Sign H
+        {0x01c2c, 0x01c33},  // Lepcha Vowel Sign E     ..Lepcha Consonant Sign T
+        {0x01c36, 0x01c37},  // Lepcha Sign Ran         ..Lepcha Sign Nukta
+        {0x01cd0, 0x01cd2},  // Vedic Tone Karshana     ..Vedic Tone Prenkha
+        {0x01cd4, 0x01ce0},  // Vedic Sign Yajurvedic Mi..Vedic Tone Rigvedic Kash
+        {0x01ce2, 0x01ce8},  // Vedic Sign Visarga Svari..Vedic Sign Visarga Anuda
+        {0x01ced, 0x01ced},  // Vedic Sign Tiryak       ..Vedic Sign Tiryak
+        {0x01cf4, 0x01cf4},  // Vedic Tone Candra Above ..Vedic Tone Candra Above
+        {0x01cf8, 0x01cf9},  // Vedic Tone Ring Above   ..Vedic Tone Double Ring A
+        {0x01dc0, 0x01dff},  // Combining Dotted Grave A..Combining Right Arrowhea
+        {0x020d0, 0x020f0},  // Combining Left Harpoon A..Combining Asterisk Above
+        {0x02cef, 0x02cf1},  // Coptic Combining Ni Abov..Coptic Combining Spiritu
+        {0x02d7f, 0x02d7f},  // Tifinagh Consonant Joine..Tifinagh Consonant Joine
+        {0x02de0, 0x02dff},  // Combining Cyrillic Lette..Combining Cyrillic Lette
+        {0x0302a, 0x0302d},  // Ideographic Level Tone M..Ideographic Entering Ton
+        {0x03099, 0x0309a},  // Combining Katakana-hirag..Combining Katakana-hirag
+        {0x0a66f, 0x0a672},  // Combining Cyrillic Vzmet..Combining Cyrillic Thous
+        {0x0a674, 0x0a67d},  // Combining Cyrillic Lette..Combining Cyrillic Payer
+        {0x0a69e, 0x0a69f},  // Combining Cyrillic Lette..Combining Cyrillic Lette
+        {0x0a6f0, 0x0a6f1},  // Bamum Combining Mark Koq..Bamum Combining Mark Tuk
+        {0x0a802, 0x0a802},  // Syloti Nagri Sign Dvisva..Syloti Nagri Sign Dvisva
+        {0x0a806, 0x0a806},  // Syloti Nagri Sign Hasant..Syloti Nagri Sign Hasant
+        {0x0a80b, 0x0a80b},  // Syloti Nagri Sign Anusva..Syloti Nagri Sign Anusva
+        {0x0a825, 0x0a826},  // Syloti Nagri Vowel Sign ..Syloti Nagri Vowel Sign
+        {0x0a82c, 0x0a82c},  // Syloti Nagri Sign Altern..Syloti Nagri Sign Altern
+        {0x0a8c4, 0x0a8c5},  // Saurashtra Sign Virama  ..Saurashtra Sign Candrabi
+        {0x0a8e0, 0x0a8f1},  // Combining Devanagari Dig..Combining Devanagari Sig
+        {0x0a8ff, 0x0a8ff},  // Devanagari Vowel Sign Ay..Devanagari Vowel Sign Ay
+        {0x0a926, 0x0a92d},  // Kayah Li Vowel Ue       ..Kayah Li Tone Calya Plop
+        {0x0a947, 0x0a951},  // Rejang Vowel Sign I     ..Rejang Consonant Sign R
+        {0x0a980, 0x0a982},  // Javanese Sign Panyangga ..Javanese Sign Layar
+        {0x0a9b3, 0x0a9b3},  // Javanese Sign Cecak Telu..Javanese Sign Cecak Telu
+        {0x0a9b6, 0x0a9b9},  // Javanese Vowel Sign Wulu..Javanese Vowel Sign Suku
+        {0x0a9bc, 0x0a9bd},  // Javanese Vowel Sign Pepe..Javanese Consonant Sign
+        {0x0a9e5, 0x0a9e5},  // Myanmar Sign Shan Saw   ..Myanmar Sign Shan Saw
+        {0x0aa29, 0x0aa2e},  // Cham Vowel Sign Aa      ..Cham Vowel Sign Oe
+        {0x0aa31, 0x0aa32},  // Cham Vowel Sign Au      ..Cham Vowel Sign Ue
+        {0x0aa35, 0x0aa36},  // Cham Consonant Sign La  ..Cham Consonant Sign Wa
+        {0x0aa43, 0x0aa43},  // Cham Consonant Sign Fina..Cham Consonant Sign Fina
+        {0x0aa4c, 0x0aa4c},  // Cham Consonant Sign Fina..Cham Consonant Sign Fina
+        {0x0aa7c, 0x0aa7c},  // Myanmar Sign Tai Laing T..Myanmar Sign Tai Laing T
+        {0x0aab0, 0x0aab0},  // Tai Viet Mai Kang       ..Tai Viet Mai Kang
+        {0x0aab2, 0x0aab4},  // Tai Viet Vowel I        ..Tai Viet Vowel U
+        {0x0aab7, 0x0aab8},  // Tai Viet Mai Khit       ..Tai Viet Vowel Ia
+        {0x0aabe, 0x0aabf},  // Tai Viet Vowel Am       ..Tai Viet Tone Mai Ek
+        {0x0aac1, 0x0aac1},  // Tai Viet Tone Mai Tho   ..Tai Viet Tone Mai Tho
+        {0x0aaec, 0x0aaed},  // Meetei Mayek Vowel Sign ..Meetei Mayek Vowel Sign
+        {0x0aaf6, 0x0aaf6},  // Meetei Mayek Virama     ..Meetei Mayek Virama
+        {0x0abe5, 0x0abe5},  // Meetei Mayek Vowel Sign ..Meetei Mayek Vowel Sign
+        {0x0abe8, 0x0abe8},  // Meetei Mayek Vowel Sign ..Meetei Mayek Vowel Sign
+        {0x0abed, 0x0abed},  // Meetei Mayek Apun Iyek  ..Meetei Mayek Apun Iyek
+        {0x0fb1e, 0x0fb1e},  // Hebrew Point Judeo-spani..Hebrew Point Judeo-spani
+        {0x0fe00, 0x0fe0f},  // Variation Selector-1    ..Variation Selector-16
+        {0x0fe20, 0x0fe2f},  // Combining Ligature Left ..Combining Cyrillic Titlo
+        {0x101fd, 0x101fd},  // Phaistos Disc Sign Combi..Phaistos Disc Sign Combi
+        {0x102e0, 0x102e0},  // Coptic Epact Thousands M..Coptic Epact Thousands M
+        {0x10376, 0x1037a},  // Combining Old Permic Let..Combining Old Permic Let
+        {0x10a01, 0x10a03},  // Kharoshthi Vowel Sign I ..Kharoshthi Vowel Sign Vo
+        {0x10a05, 0x10a06},  // Kharoshthi Vowel Sign E ..Kharoshthi Vowel Sign O
+        {0x10a0c, 0x10a0f},  // Kharoshthi Vowel Length ..Kharoshthi Sign Visarga
+        {0x10a38, 0x10a3a},  // Kharoshthi Sign Bar Abov..Kharoshthi Sign Dot Belo
+        {0x10a3f, 0x10a3f},  // Kharoshthi Virama       ..Kharoshthi Virama
+        {0x10ae5, 0x10ae6},  // Manichaean Abbreviation ..Manichaean Abbreviation
+        {0x10d24, 0x10d27},  // Hanifi Rohingya Sign Har..Hanifi Rohingya Sign Tas
+        {0x10eab, 0x10eac},  // Yezidi Combining Hamza M..Yezidi Combining Madda M
+        {0x10efd, 0x10eff},  // (nil)                   ..(nil)
+        {0x10f46, 0x10f50},  // Sogdian Combining Dot Be..Sogdian Combining Stroke
+        {0x10f82, 0x10f85},  // Old Uyghur Combining Dot..Old Uyghur Combining Two
+        {0x11001, 0x11001},  // Brahmi Sign Anusvara    ..Brahmi Sign Anusvara
+        {0x11038, 0x11046},  // Brahmi Vowel Sign Aa    ..Brahmi Virama
+        {0x11070, 0x11070},  // Brahmi Sign Old Tamil Vi..Brahmi Sign Old Tamil Vi
+        {0x11073, 0x11074},  // Brahmi Vowel Sign Old Ta..Brahmi Vowel Sign Old Ta
+        {0x1107f, 0x11081},  // Brahmi Number Joiner    ..Kaithi Sign Anusvara
+        {0x110b3, 0x110b6},  // Kaithi Vowel Sign U     ..Kaithi Vowel Sign Ai
+        {0x110b9, 0x110ba},  // Kaithi Sign Virama      ..Kaithi Sign Nukta
+        {0x110c2, 0x110c2},  // Kaithi Vowel Sign Vocali..Kaithi Vowel Sign Vocali
+        {0x11100, 0x11102},  // Chakma Sign Candrabindu ..Chakma Sign Visarga
+        {0x11127, 0x1112b},  // Chakma Vowel Sign A     ..Chakma Vowel Sign Uu
+        {0x1112d, 0x11134},  // Chakma Vowel Sign Ai    ..Chakma Maayyaa
+        {0x11173, 0x11173},  // Mahajani Sign Nukta     ..Mahajani Sign Nukta
+        {0x11180, 0x11181},  // Sharada Sign Candrabindu..Sharada Sign Anusvara
+        {0x111b6, 0x111be},  // Sharada Vowel Sign U    ..Sharada Vowel Sign O
+        {0x111c9, 0x111cc},  // Sharada Sandhi Mark     ..Sharada Extra Short Vowe
+        {0x111cf, 0x111cf},  // Sharada Sign Inverted Ca..Sharada Sign Inverted Ca
+        {0x1122f, 0x11231},  // Khojki Vowel Sign U     ..Khojki Vowel Sign Ai
+        {0x11234, 0x11234},  // Khojki Sign Anusvara    ..Khojki Sign Anusvara
+        {0x11236, 0x11237},  // Khojki Sign Nukta       ..Khojki Sign Shadda
+        {0x1123e, 0x1123e},  // Khojki Sign Sukun       ..Khojki Sign Sukun
+        {0x11241, 0x11241},  // (nil)                   ..(nil)
+        {0x112df, 0x112df},  // Khudawadi Sign Anusvara ..Khudawadi Sign Anusvara
+        {0x112e3, 0x112ea},  // Khudawadi Vowel Sign U  ..Khudawadi Sign Virama
+        {0x11300, 0x11301},  // Grantha Sign Combining A..Grantha Sign Candrabindu
+        {0x1133b, 0x1133c},  // Combining Bindu Below   ..Grantha Sign Nukta
+        {0x11340, 0x11340},  // Grantha Vowel Sign Ii   ..Grantha Vowel Sign Ii
+        {0x11366, 0x1136c},  // Combining Grantha Digit ..Combining Grantha Digit
+        {0x11370, 0x11374},  // Combining Grantha Letter..Combining Grantha Letter
+        {0x11438, 0x1143f},  // Newa Vowel Sign U       ..Newa Vowel Sign Ai
+        {0x11442, 0x11444},  // Newa Sign Virama        ..Newa Sign Anusvara
+        {0x11446, 0x11446},  // Newa Sign Nukta         ..Newa Sign Nukta
+        {0x1145e, 0x1145e},  // Newa Sandhi Mark        ..Newa Sandhi Mark
+        {0x114b3, 0x114b8},  // Tirhuta Vowel Sign U    ..Tirhuta Vowel Sign Vocal
+        {0x114ba, 0x114ba},  // Tirhuta Vowel Sign Short..Tirhuta Vowel Sign Short
+        {0x114bf, 0x114c0},  // Tirhuta Sign Candrabindu..Tirhuta Sign Anusvara
+        {0x114c2, 0x114c3},  // Tirhuta Sign Virama     ..Tirhuta Sign Nukta
+        {0x115b2, 0x115b5},  // Siddham Vowel Sign U    ..Siddham Vowel Sign Vocal
+        {0x115bc, 0x115bd},  // Siddham Sign Candrabindu..Siddham Sign Anusvara
+        {0x115bf, 0x115c0},  // Siddham Sign Virama     ..Siddham Sign Nukta
+        {0x115dc, 0x115dd},  // Siddham Vowel Sign Alter..Siddham Vowel Sign Alter
+        {0x11633, 0x1163a},  // Modi Vowel Sign U       ..Modi Vowel Sign Ai
+        {0x1163d, 0x1163d},  // Modi Sign Anusvara      ..Modi Sign Anusvara
+        {0x1163f, 0x11640},  // Modi Sign Virama        ..Modi Sign Ardhacandra
+        {0x116ab, 0x116ab},  // Takri Sign Anusvara     ..Takri Sign Anusvara
+        {0x116ad, 0x116ad},  // Takri Vowel Sign Aa     ..Takri Vowel Sign Aa
+        {0x116b0, 0x116b5},  // Takri Vowel Sign U      ..Takri Vowel Sign Au
+        {0x116b7, 0x116b7},  // Takri Sign Nukta        ..Takri Sign Nukta
+        {0x1171d, 0x1171f},  // Ahom Consonant Sign Medi..Ahom Consonant Sign Medi
+        {0x11722, 0x11725},  // Ahom Vowel Sign I       ..Ahom Vowel Sign Uu
+        {0x11727, 0x1172b},  // Ahom Vowel Sign Aw      ..Ahom Sign Killer
+        {0x1182f, 0x11837},  // Dogra Vowel Sign U      ..Dogra Sign Anusvara
+        {0x11839, 0x1183a},  // Dogra Sign Virama       ..Dogra Sign Nukta
+        {0x1193b, 0x1193c},  // Dives Akuru Sign Anusvar..Dives Akuru Sign Candrab
+        {0x1193e, 0x1193e},  // Dives Akuru Virama      ..Dives Akuru Virama
+        {0x11943, 0x11943},  // Dives Akuru Sign Nukta  ..Dives Akuru Sign Nukta
+        {0x119d4, 0x119d7},  // Nandinagari Vowel Sign U..Nandinagari Vowel Sign V
+        {0x119da, 0x119db},  // Nandinagari Vowel Sign E..Nandinagari Vowel Sign A
+        {0x119e0, 0x119e0},  // Nandinagari Sign Virama ..Nandinagari Sign Virama
+        {0x11a01, 0x11a0a},  // Zanabazar Square Vowel S..Zanabazar Square Vowel L
+        {0x11a33, 0x11a38},  // Zanabazar Square Final C..Zanabazar Square Sign An
+        {0x11a3b, 0x11a3e},  // Zanabazar Square Cluster..Zanabazar Square Cluster
+        {0x11a47, 0x11a47},  // Zanabazar Square Subjoin..Zanabazar Square Subjoin
+        {0x11a51, 0x11a56},  // Soyombo Vowel Sign I    ..Soyombo Vowel Sign Oe
+        {0x11a59, 0x11a5b},  // Soyombo Vowel Sign Vocal..Soyombo Vowel Length Mar
+        {0x11a8a, 0x11a96},  // Soyombo Final Consonant ..Soyombo Sign Anusvara
+        {0x11a98, 0x11a99},  // Soyombo Gemination Mark ..Soyombo Subjoiner
+        {0x11c30, 0x11c36},  // Bhaiksuki Vowel Sign I  ..Bhaiksuki Vowel Sign Voc
+        {0x11c38, 0x11c3d},  // Bhaiksuki Vowel Sign E  ..Bhaiksuki Sign Anusvara
+        {0x11c3f, 0x11c3f},  // Bhaiksuki Sign Virama   ..Bhaiksuki Sign Virama
+        {0x11c92, 0x11ca7},  // Marchen Subjoined Letter..Marchen Subjoined Letter
+        {0x11caa, 0x11cb0},  // Marchen Subjoined Letter..Marchen Vowel Sign Aa
+        {0x11cb2, 0x11cb3},  // Marchen Vowel Sign U    ..Marchen Vowel Sign E
+        {0x11cb5, 0x11cb6},  // Marchen Sign Anusvara   ..Marchen Sign Candrabindu
+        {0x11d31, 0x11d36},  // Masaram Gondi Vowel Sign..Masaram Gondi Vowel Sign
+        {0x11d3a, 0x11d3a},  // Masaram Gondi Vowel Sign..Masaram Gondi Vowel Sign
+        {0x11d3c, 0x11d3d},  // Masaram Gondi Vowel Sign..Masaram Gondi Vowel Sign
+        {0x11d3f, 0x11d45},  // Masaram Gondi Vowel Sign..Masaram Gondi Virama
+        {0x11d47, 0x11d47},  // Masaram Gondi Ra-kara   ..Masaram Gondi Ra-kara
+        {0x11d90, 0x11d91},  // Gunjala Gondi Vowel Sign..Gunjala Gondi Vowel Sign
+        {0x11d95, 0x11d95},  // Gunjala Gondi Sign Anusv..Gunjala Gondi Sign Anusv
+        {0x11d97, 0x11d97},  // Gunjala Gondi Virama    ..Gunjala Gondi Virama
+        {0x11ef3, 0x11ef4},  // Makasar Vowel Sign I    ..Makasar Vowel Sign U
+        {0x11f00, 0x11f01},  // (nil)                   ..(nil)
+        {0x11f36, 0x11f3a},  // (nil)                   ..(nil)
+        {0x11f40, 0x11f40},  // (nil)                   ..(nil)
+        {0x11f42, 0x11f42},  // (nil)                   ..(nil)
+        {0x13440, 0x13440},  // (nil)                   ..(nil)
+        {0x13447, 0x13455},  // (nil)                   ..(nil)
+        {0x16af0, 0x16af4},  // Bassa Vah Combining High..Bassa Vah Combining High
+        {0x16b30, 0x16b36},  // Pahawh Hmong Mark Cim Tu..Pahawh Hmong Mark Cim Ta
+        {0x16f4f, 0x16f4f},  // Miao Sign Consonant Modi..Miao Sign Consonant Modi
+        {0x16f8f, 0x16f92},  // Miao Tone Right         ..Miao Tone Below
+        {0x16fe4, 0x16fe4},  // Khitan Small Script Fill..Khitan Small Script Fill
+        {0x1bc9d, 0x1bc9e},  // Duployan Thick Letter Se..Duployan Double Mark
+        {0x1cf00, 0x1cf2d},  // Znamenny Combining Mark ..Znamenny Combining Mark
+        {0x1cf30, 0x1cf46},  // Znamenny Combining Tonal..Znamenny Priznak Modifie
+        {0x1d167, 0x1d169},  // Musical Symbol Combining..Musical Symbol Combining
+        {0x1d17b, 0x1d182},  // Musical Symbol Combining..Musical Symbol Combining
+        {0x1d185, 0x1d18b},  // Musical Symbol Combining..Musical Symbol Combining
+        {0x1d1aa, 0x1d1ad},  // Musical Symbol Combining..Musical Symbol Combining
+        {0x1d242, 0x1d244},  // Combining Greek Musical ..Combining Greek Musical
+        {0x1da00, 0x1da36},  // Signwriting Head Rim    ..Signwriting Air Sucking
+        {0x1da3b, 0x1da6c},  // Signwriting Mouth Closed..Signwriting Excitement
+        {0x1da75, 0x1da75},  // Signwriting Upper Body T..Signwriting Upper Body T
+        {0x1da84, 0x1da84},  // Signwriting Location Hea..Signwriting Location Hea
+        {0x1da9b, 0x1da9f},  // Signwriting Fill Modifie..Signwriting Fill Modifie
+        {0x1daa1, 0x1daaf},  // Signwriting Rotation Mod..Signwriting Rotation Mod
+        {0x1e000, 0x1e006},  // Combining Glagolitic Let..Combining Glagolitic Let
+        {0x1e008, 0x1e018},  // Combining Glagolitic Let..Combining Glagolitic Let
+        {0x1e01b, 0x1e021},  // Combining Glagolitic Let..Combining Glagolitic Let
+        {0x1e023, 0x1e024},  // Combining Glagolitic Let..Combining Glagolitic Let
+        {0x1e026, 0x1e02a},  // Combining Glagolitic Let..Combining Glagolitic Let
+        {0x1e08f, 0x1e08f},  // (nil)                   ..(nil)
+        {0x1e130, 0x1e136},  // Nyiakeng Puachue Hmong T..Nyiakeng Puachue Hmong T
+        {0x1e2ae, 0x1e2ae},  // Toto Sign Rising Tone   ..Toto Sign Rising Tone
+        {0x1e2ec, 0x1e2ef},  // Wancho Tone Tup         ..Wancho Tone Koini
+        {0x1e4ec, 0x1e4ef},  // (nil)                   ..(nil)
+        {0x1e8d0, 0x1e8d6},  // Mende Kikakui Combining ..Mende Kikakui Combining
+        {0x1e944, 0x1e94a},  // Adlam Alif Lengthener   ..Adlam Nukta
+        {0xe0100, 0xe01ef},  // Variation Selector-17   ..Variation Selector-256
+    };
+
+    // https://github.com/jquast/wcwidth/blob/master/wcwidth/table_wide.py
+    // from https://github.com/jquast/wcwidth/pull/64
+    // at commit 1b9b6585b0080ea5cb88dc9815796505724793fe (2022-12-16):
+    private static final int[][] WIDE_EASTASIAN = {
+        {0x01100, 0x0115f},  // Hangul Choseong Kiyeok  ..Hangul Choseong Filler
+        {0x0231a, 0x0231b},  // Watch                   ..Hourglass
+        {0x02329, 0x0232a},  // Left-pointing Angle Brac..Right-pointing Angle Bra
+        {0x023e9, 0x023ec},  // Black Right-pointing Dou..Black Down-pointing Doub
+        {0x023f0, 0x023f0},  // Alarm Clock             ..Alarm Clock
+        {0x023f3, 0x023f3},  // Hourglass With Flowing S..Hourglass With Flowing S
+        {0x025fd, 0x025fe},  // White Medium Small Squar..Black Medium Small Squar
+        {0x02614, 0x02615},  // Umbrella With Rain Drops..Hot Beverage
+        {0x02648, 0x02653},  // Aries                   ..Pisces
+        {0x0267f, 0x0267f},  // Wheelchair Symbol       ..Wheelchair Symbol
+        {0x02693, 0x02693},  // Anchor                  ..Anchor
+        {0x026a1, 0x026a1},  // High Voltage Sign       ..High Voltage Sign
+        {0x026aa, 0x026ab},  // Medium White Circle     ..Medium Black Circle
+        {0x026bd, 0x026be},  // Soccer Ball             ..Baseball
+        {0x026c4, 0x026c5},  // Snowman Without Snow    ..Sun Behind Cloud
+        {0x026ce, 0x026ce},  // Ophiuchus               ..Ophiuchus
+        {0x026d4, 0x026d4},  // No Entry                ..No Entry
+        {0x026ea, 0x026ea},  // Church                  ..Church
+        {0x026f2, 0x026f3},  // Fountain                ..Flag In Hole
+        {0x026f5, 0x026f5},  // Sailboat                ..Sailboat
+        {0x026fa, 0x026fa},  // Tent                    ..Tent
+        {0x026fd, 0x026fd},  // Fuel Pump               ..Fuel Pump
+        {0x02705, 0x02705},  // White Heavy Check Mark  ..White Heavy Check Mark
+        {0x0270a, 0x0270b},  // Raised Fist             ..Raised Hand
+        {0x02728, 0x02728},  // Sparkles                ..Sparkles
+        {0x0274c, 0x0274c},  // Cross Mark              ..Cross Mark
+        {0x0274e, 0x0274e},  // Negative Squared Cross M..Negative Squared Cross M
+        {0x02753, 0x02755},  // Black Question Mark Orna..White Exclamation Mark O
+        {0x02757, 0x02757},  // Heavy Exclamation Mark S..Heavy Exclamation Mark S
+        {0x02795, 0x02797},  // Heavy Plus Sign         ..Heavy Division Sign
+        {0x027b0, 0x027b0},  // Curly Loop              ..Curly Loop
+        {0x027bf, 0x027bf},  // Double Curly Loop       ..Double Curly Loop
+        {0x02b1b, 0x02b1c},  // Black Large Square      ..White Large Square
+        {0x02b50, 0x02b50},  // White Medium Star       ..White Medium Star
+        {0x02b55, 0x02b55},  // Heavy Large Circle      ..Heavy Large Circle
+        {0x02e80, 0x02e99},  // Cjk Radical Repeat      ..Cjk Radical Rap
+        {0x02e9b, 0x02ef3},  // Cjk Radical Choke       ..Cjk Radical C-simplified
+        {0x02f00, 0x02fd5},  // Kangxi Radical One      ..Kangxi Radical Flute
+        {0x02ff0, 0x02ffb},  // Ideographic Description ..Ideographic Description
+        {0x03000, 0x0303e},  // Ideographic Space       ..Ideographic Variation In
+        {0x03041, 0x03096},  // Hiragana Letter Small A ..Hiragana Letter Small Ke
+        {0x03099, 0x030ff},  // Combining Katakana-hirag..Katakana Digraph Koto
+        {0x03105, 0x0312f},  // Bopomofo Letter B       ..Bopomofo Letter Nn
+        {0x03131, 0x0318e},  // Hangul Letter Kiyeok    ..Hangul Letter Araeae
+        {0x03190, 0x031e3},  // Ideographic Annotation L..Cjk Stroke Q
+        {0x031f0, 0x0321e},  // Katakana Letter Small Ku..Parenthesized Korean Cha
+        {0x03220, 0x03247},  // Parenthesized Ideograph ..Circled Ideograph Koto
+        {0x03250, 0x04dbf},  // Partnership Sign        ..Cjk Unified Ideograph-4d
+        {0x04e00, 0x0a48c},  // Cjk Unified Ideograph-4e..Yi Syllable Yyr
+        {0x0a490, 0x0a4c6},  // Yi Radical Qot          ..Yi Radical Ke
+        {0x0a960, 0x0a97c},  // Hangul Choseong Tikeut-m..Hangul Choseong Ssangyeo
+        {0x0ac00, 0x0d7a3},  // Hangul Syllable Ga      ..Hangul Syllable Hih
+        {0x0f900, 0x0faff},  // Cjk Compatibility Ideogr..(nil)
+        {0x0fe10, 0x0fe19},  // Presentation Form For Ve..Presentation Form For Ve
+        {0x0fe30, 0x0fe52},  // Presentation Form For Ve..Small Full Stop
+        {0x0fe54, 0x0fe66},  // Small Semicolon         ..Small Equals Sign
+        {0x0fe68, 0x0fe6b},  // Small Reverse Solidus   ..Small Commercial At
+        {0x0ff01, 0x0ff60},  // Fullwidth Exclamation Ma..Fullwidth Right White Pa
+        {0x0ffe0, 0x0ffe6},  // Fullwidth Cent Sign     ..Fullwidth Won Sign
+        {0x16fe0, 0x16fe4},  // Tangut Iteration Mark   ..Khitan Small Script Fill
+        {0x16ff0, 0x16ff1},  // Vietnamese Alternate Rea..Vietnamese Alternate Rea
+        {0x17000, 0x187f7},  // (nil)                   ..(nil)
+        {0x18800, 0x18cd5},  // Tangut Component-001    ..Khitan Small Script Char
+        {0x18d00, 0x18d08},  // (nil)                   ..(nil)
+        {0x1aff0, 0x1aff3},  // Katakana Letter Minnan T..Katakana Letter Minnan T
+        {0x1aff5, 0x1affb},  // Katakana Letter Minnan T..Katakana Letter Minnan N
+        {0x1affd, 0x1affe},  // Katakana Letter Minnan N..Katakana Letter Minnan N
+        {0x1b000, 0x1b122},  // Katakana Letter Archaic ..Katakana Letter Archaic
+        {0x1b132, 0x1b132},  // (nil)                   ..(nil)
+        {0x1b150, 0x1b152},  // Hiragana Letter Small Wi..Hiragana Letter Small Wo
+        {0x1b155, 0x1b155},  // (nil)                   ..(nil)
+        {0x1b164, 0x1b167},  // Katakana Letter Small Wi..Katakana Letter Small N
+        {0x1b170, 0x1b2fb},  // Nushu Character-1b170   ..Nushu Character-1b2fb
+        {0x1f004, 0x1f004},  // Mahjong Tile Red Dragon ..Mahjong Tile Red Dragon
+        {0x1f0cf, 0x1f0cf},  // Playing Card Black Joker..Playing Card Black Joker
+        {0x1f18e, 0x1f18e},  // Negative Squared Ab     ..Negative Squared Ab
+        {0x1f191, 0x1f19a},  // Squared Cl              ..Squared Vs
+        {0x1f200, 0x1f202},  // Square Hiragana Hoka    ..Squared Katakana Sa
+        {0x1f210, 0x1f23b},  // Squared Cjk Unified Ideo..Squared Cjk Unified Ideo
+        {0x1f240, 0x1f248},  // Tortoise Shell Bracketed..Tortoise Shell Bracketed
+        {0x1f250, 0x1f251},  // Circled Ideograph Advant..Circled Ideograph Accept
+        {0x1f260, 0x1f265},  // Rounded Symbol For Fu   ..Rounded Symbol For Cai
+        {0x1f300, 0x1f320},  // Cyclone                 ..Shooting Star
+        {0x1f32d, 0x1f335},  // Hot Dog                 ..Cactus
+        {0x1f337, 0x1f37c},  // Tulip                   ..Baby Bottle
+        {0x1f37e, 0x1f393},  // Bottle With Popping Cork..Graduation Cap
+        {0x1f3a0, 0x1f3ca},  // Carousel Horse          ..Swimmer
+        {0x1f3cf, 0x1f3d3},  // Cricket Bat And Ball    ..Table Tennis Paddle And
+        {0x1f3e0, 0x1f3f0},  // House Building          ..European Castle
+        {0x1f3f4, 0x1f3f4},  // Waving Black Flag       ..Waving Black Flag
+        {0x1f3f8, 0x1f43e},  // Badminton Racquet And Sh..Paw Prints
+        {0x1f440, 0x1f440},  // Eyes                    ..Eyes
+        {0x1f442, 0x1f4fc},  // Ear                     ..Videocassette
+        {0x1f4ff, 0x1f53d},  // Prayer Beads            ..Down-pointing Small Red
+        {0x1f54b, 0x1f54e},  // Kaaba                   ..Menorah With Nine Branch
+        {0x1f550, 0x1f567},  // Clock Face One Oclock   ..Clock Face Twelve-thirty
+        {0x1f57a, 0x1f57a},  // Man Dancing             ..Man Dancing
+        {0x1f595, 0x1f596},  // Reversed Hand With Middl..Raised Hand With Part Be
+        {0x1f5a4, 0x1f5a4},  // Black Heart             ..Black Heart
+        {0x1f5fb, 0x1f64f},  // Mount Fuji              ..Person With Folded Hands
+        {0x1f680, 0x1f6c5},  // Rocket                  ..Left Luggage
+        {0x1f6cc, 0x1f6cc},  // Sleeping Accommodation  ..Sleeping Accommodation
+        {0x1f6d0, 0x1f6d2},  // Place Of Worship        ..Shopping Trolley
+        {0x1f6d5, 0x1f6d7},  // Hindu Temple            ..Elevator
+        {0x1f6dc, 0x1f6df},  // (nil)                   ..Ring Buoy
+        {0x1f6eb, 0x1f6ec},  // Airplane Departure      ..Airplane Arriving
+        {0x1f6f4, 0x1f6fc},  // Scooter                 ..Roller Skate
+        {0x1f7e0, 0x1f7eb},  // Large Orange Circle     ..Large Brown Square
+        {0x1f7f0, 0x1f7f0},  // Heavy Equals Sign       ..Heavy Equals Sign
+        {0x1f90c, 0x1f93a},  // Pinched Fingers         ..Fencer
+        {0x1f93c, 0x1f945},  // Wrestlers               ..Goal Net
+        {0x1f947, 0x1f9ff},  // First Place Medal       ..Nazar Amulet
+        {0x1fa70, 0x1fa7c},  // Ballet Shoes            ..Crutch
+        {0x1fa80, 0x1fa88},  // Yo-yo                   ..(nil)
+        {0x1fa90, 0x1fabd},  // Ringed Planet           ..(nil)
+        {0x1fabf, 0x1fac5},  // (nil)                   ..Person With Crown
+        {0x1face, 0x1fadb},  // (nil)                   ..(nil)
+        {0x1fae0, 0x1fae8},  // Melting Face            ..(nil)
+        {0x1faf0, 0x1faf8},  // Hand With Index Finger A..(nil)
+        {0x20000, 0x2fffd},  // Cjk Unified Ideograph-20..(nil)
+        {0x30000, 0x3fffd},  // Cjk Unified Ideograph-30..(nil)
+    };
+
+
+    private static boolean intable(int[][] table, int c) {
+        // First quick check f|| Latin1 etc. characters.
+        if (c < table[0][0]) return false;
+
+        // Binary search in table.
+        int bot = 0;
+        int top = table.length - 1; // (int)(size / sizeof(struct interval) - 1);
+        while (top >= bot) {
+            int mid = (bot + top) / 2;
+            if (table[mid][1] < c) {
+                bot = mid + 1;
+            } else if (table[mid][0] > c) {
+                top = mid - 1;
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Return the terminal display width of a code point: 0, 1 || 2. */
+    public static int width(int ucs) {
+        if (ucs == 0 ||
+            ucs == 0x034F ||
+            (0x200B <= ucs && ucs <= 0x200F) ||
+            ucs == 0x2028 ||
+            ucs == 0x2029 ||
+            (0x202A <= ucs && ucs <= 0x202E) ||
+            (0x2060 <= ucs && ucs <= 0x2063)) {
+            return 0;
+        }
+
+        // C0/C1 control characters
+        // Termux change: Return 0 instead of -1.
+        if (ucs < 32 || (0x07F <= ucs && ucs < 0x0A0)) return 0;
+
+        // combining characters with zero width
+        if (intable(ZERO_WIDTH, ucs)) return 0;
+
+        return intable(WIDE_EASTASIAN, ucs) ? 2 : 1;
+    }
+
+    /** The width at an index position in a java char array. */
+    public static int width(char[] chars, int index) {
+        char c = chars[index];
+        return Character.isHighSurrogate(c) ? width(Character.toCodePoint(c, chars[index + 1])) : width(c);
+    }
+
+    /**
+     * The zero width characters count like combining characters in the `chars` array from start
+     * index to end index (exclusive).
+     */
+    public static int zeroWidthCharsCount(char[] chars, int start, int end) {
+        if (start < 0 || start >= chars.length)
+            return 0;
+
+        int count = 0;
+        for (int i = start; i < end && i < chars.length;) {
+            if (Character.isHighSurrogate(chars[i])) {
+                if (width(Character.toCodePoint(chars[i], chars[i + 1])) <= 0) {
+                    count++;
+                }
+                i += 2;
+            } else {
+                if (width(chars[i]) <= 0) {
+                    count++;
+                }
+                i++;
+            }
+        }
+        return count;
+    }
+
+}

--- a/terminal-view/build.gradle
+++ b/terminal-view/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.library'
+
+android {
+    namespace "com.termux.view"
+    compileSdk 36
+
+    defaultConfig {
+        minSdk 24
+        targetSdk 36
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation "androidx.annotation:annotation:1.9.0"
+    api project(":terminal-emulator")
+}

--- a/terminal-view/proguard-rules.pro
+++ b/terminal-view/proguard-rules.pro
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /Users/fornwall/lib/android-sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/terminal-view/src/main/AndroidManifest.xml
+++ b/terminal-view/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/terminal-view/src/main/java/com/termux/view/GestureAndScaleRecognizer.java
+++ b/terminal-view/src/main/java/com/termux/view/GestureAndScaleRecognizer.java
@@ -1,0 +1,112 @@
+package com.termux.view;
+
+import android.content.Context;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
+
+/** A combination of {@link GestureDetector} and {@link ScaleGestureDetector}. */
+final class GestureAndScaleRecognizer {
+
+    public interface Listener {
+        boolean onSingleTapUp(MotionEvent e);
+
+        boolean onDoubleTap(MotionEvent e);
+
+        boolean onScroll(MotionEvent e2, float dx, float dy);
+
+        boolean onFling(MotionEvent e, float velocityX, float velocityY);
+
+        boolean onScale(float focusX, float focusY, float scale);
+
+        boolean onDown(float x, float y);
+
+        boolean onUp(MotionEvent e);
+
+        void onLongPress(MotionEvent e);
+    }
+
+    private final GestureDetector mGestureDetector;
+    private final ScaleGestureDetector mScaleDetector;
+    final Listener mListener;
+    boolean isAfterLongPress;
+
+    public GestureAndScaleRecognizer(Context context, Listener listener) {
+        mListener = listener;
+
+        mGestureDetector = new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
+            @Override
+            public boolean onScroll(MotionEvent e1, MotionEvent e2, float dx, float dy) {
+                return mListener.onScroll(e2, dx, dy);
+            }
+
+            @Override
+            public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+                return mListener.onFling(e2, velocityX, velocityY);
+            }
+
+            @Override
+            public boolean onDown(MotionEvent e) {
+                return mListener.onDown(e.getX(), e.getY());
+            }
+
+            @Override
+            public void onLongPress(MotionEvent e) {
+                mListener.onLongPress(e);
+                isAfterLongPress = true;
+            }
+        }, null, true /* ignoreMultitouch */);
+
+        mGestureDetector.setOnDoubleTapListener(new GestureDetector.OnDoubleTapListener() {
+            @Override
+            public boolean onSingleTapConfirmed(MotionEvent e) {
+                return mListener.onSingleTapUp(e);
+            }
+
+            @Override
+            public boolean onDoubleTap(MotionEvent e) {
+                return mListener.onDoubleTap(e);
+            }
+
+            @Override
+            public boolean onDoubleTapEvent(MotionEvent e) {
+                return true;
+            }
+        });
+
+        mScaleDetector = new ScaleGestureDetector(context, new ScaleGestureDetector.SimpleOnScaleGestureListener() {
+            @Override
+            public boolean onScaleBegin(ScaleGestureDetector detector) {
+                return true;
+            }
+
+            @Override
+            public boolean onScale(ScaleGestureDetector detector) {
+                return mListener.onScale(detector.getFocusX(), detector.getFocusY(), detector.getScaleFactor());
+            }
+        });
+        mScaleDetector.setQuickScaleEnabled(false);
+    }
+
+    public void onTouchEvent(MotionEvent event) {
+        mGestureDetector.onTouchEvent(event);
+        mScaleDetector.onTouchEvent(event);
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                isAfterLongPress = false;
+                break;
+            case MotionEvent.ACTION_UP:
+                if (!isAfterLongPress) {
+                    // This behaviour is desired when in e.g. vim with mouse events, where we do not
+                    // want to move the cursor when lifting finger after a long press.
+                    mListener.onUp(event);
+                }
+                break;
+        }
+    }
+
+    public boolean isInProgress() {
+        return mScaleDetector.isInProgress();
+    }
+
+}

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -1,0 +1,249 @@
+package com.termux.view;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.Typeface;
+
+import com.termux.terminal.TerminalBuffer;
+import com.termux.terminal.TerminalEmulator;
+import com.termux.terminal.TerminalRow;
+import com.termux.terminal.TextStyle;
+import com.termux.terminal.WcWidth;
+
+/**
+ * Renderer of a {@link TerminalEmulator} into a {@link Canvas}.
+ * <p/>
+ * Saves font metrics, so needs to be recreated each time the typeface or font size changes.
+ */
+public final class TerminalRenderer {
+
+    final int mTextSize;
+    final Typeface mTypeface;
+    private final Paint mTextPaint = new Paint();
+
+    /** The width of a single mono spaced character obtained by {@link Paint#measureText(String)} on a single 'X'. */
+    final float mFontWidth;
+    /** The {@link Paint#getFontSpacing()}. See http://www.fampennings.nl/maarten/android/08numgrid/font.png */
+    final int mFontLineSpacing;
+    /** The {@link Paint#ascent()}. See http://www.fampennings.nl/maarten/android/08numgrid/font.png */
+    private final int mFontAscent;
+    /** The {@link #mFontLineSpacing} + {@link #mFontAscent}. */
+    final int mFontLineSpacingAndAscent;
+
+    private final float[] asciiMeasures = new float[127];
+
+    public TerminalRenderer(int textSize, Typeface typeface) {
+        mTextSize = textSize;
+        mTypeface = typeface;
+
+        mTextPaint.setTypeface(typeface);
+        mTextPaint.setAntiAlias(true);
+        mTextPaint.setTextSize(textSize);
+
+        mFontLineSpacing = (int) Math.ceil(mTextPaint.getFontSpacing());
+        mFontAscent = (int) Math.ceil(mTextPaint.ascent());
+        mFontLineSpacingAndAscent = mFontLineSpacing + mFontAscent;
+        mFontWidth = mTextPaint.measureText("X");
+
+        StringBuilder sb = new StringBuilder(" ");
+        for (int i = 0; i < asciiMeasures.length; i++) {
+            sb.setCharAt(0, (char) i);
+            asciiMeasures[i] = mTextPaint.measureText(sb, 0, 1);
+        }
+    }
+
+    /** Render the terminal to a canvas with at a specified row scroll, and an optional rectangular selection. */
+    public final void render(TerminalEmulator mEmulator, Canvas canvas, int topRow,
+                             int selectionY1, int selectionY2, int selectionX1, int selectionX2) {
+        final boolean reverseVideo = mEmulator.isReverseVideo();
+        final int endRow = topRow + mEmulator.mRows;
+        final int columns = mEmulator.mColumns;
+        final int cursorCol = mEmulator.getCursorCol();
+        final int cursorRow = mEmulator.getCursorRow();
+        final boolean cursorVisible = mEmulator.shouldCursorBeVisible();
+        final TerminalBuffer screen = mEmulator.getScreen();
+        final int[] palette = mEmulator.mColors.mCurrentColors;
+        final int cursorShape = mEmulator.getCursorStyle();
+
+        if (reverseVideo)
+            canvas.drawColor(palette[TextStyle.COLOR_INDEX_FOREGROUND], PorterDuff.Mode.SRC);
+
+        float heightOffset = mFontLineSpacingAndAscent;
+        for (int row = topRow; row < endRow; row++) {
+            heightOffset += mFontLineSpacing;
+
+            final int cursorX = (row == cursorRow && cursorVisible) ? cursorCol : -1;
+            int selx1 = -1, selx2 = -1;
+            if (row >= selectionY1 && row <= selectionY2) {
+                if (row == selectionY1) selx1 = selectionX1;
+                selx2 = (row == selectionY2) ? selectionX2 : mEmulator.mColumns;
+            }
+
+            TerminalRow lineObject = screen.allocateFullLineIfNecessary(screen.externalToInternalRow(row));
+            final char[] line = lineObject.mText;
+            final int charsUsedInLine = lineObject.getSpaceUsed();
+
+            long lastRunStyle = 0;
+            boolean lastRunInsideCursor = false;
+            boolean lastRunInsideSelection = false;
+            int lastRunStartColumn = -1;
+            int lastRunStartIndex = 0;
+            boolean lastRunFontWidthMismatch = false;
+            int currentCharIndex = 0;
+            float measuredWidthForRun = 0.f;
+
+            for (int column = 0; column < columns; ) {
+                final char charAtIndex = line[currentCharIndex];
+                final boolean charIsHighsurrogate = Character.isHighSurrogate(charAtIndex);
+                final int charsForCodePoint = charIsHighsurrogate ? 2 : 1;
+                final int codePoint = charIsHighsurrogate ? Character.toCodePoint(charAtIndex, line[currentCharIndex + 1]) : charAtIndex;
+                final int codePointWcWidth = WcWidth.width(codePoint);
+                final boolean insideCursor = (cursorX == column || (codePointWcWidth == 2 && cursorX == column + 1));
+                final boolean insideSelection = column >= selx1 && column <= selx2;
+                final long style = lineObject.getStyle(column);
+
+                // Check if the measured text width for this code point is not the same as that expected by wcwidth().
+                // This could happen for some fonts which are not truly monospace, or for more exotic characters such as
+                // smileys which android font renders as wide.
+                // If this is detected, we draw this code point scaled to match what wcwidth() expects.
+                final float measuredCodePointWidth = (codePoint < asciiMeasures.length) ? asciiMeasures[codePoint] : mTextPaint.measureText(line,
+                    currentCharIndex, charsForCodePoint);
+                final boolean fontWidthMismatch = Math.abs(measuredCodePointWidth / mFontWidth - codePointWcWidth) > 0.01;
+
+                if (style != lastRunStyle || insideCursor != lastRunInsideCursor || insideSelection != lastRunInsideSelection || fontWidthMismatch || lastRunFontWidthMismatch) {
+                    if (column == 0) {
+                        // Skip first column as there is nothing to draw, just record the current style.
+                    } else {
+                        final int columnWidthSinceLastRun = column - lastRunStartColumn;
+                        final int charsSinceLastRun = currentCharIndex - lastRunStartIndex;
+                        int cursorColor = lastRunInsideCursor ? mEmulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR] : 0;
+                        boolean invertCursorTextColor = false;
+                        if (lastRunInsideCursor && cursorShape == TerminalEmulator.TERMINAL_CURSOR_STYLE_BLOCK) {
+                            invertCursorTextColor = true;
+                        }
+                        drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun,
+                            lastRunStartIndex, charsSinceLastRun, measuredWidthForRun,
+                            cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
+                    }
+                    measuredWidthForRun = 0.f;
+                    lastRunStyle = style;
+                    lastRunInsideCursor = insideCursor;
+                    lastRunInsideSelection = insideSelection;
+                    lastRunStartColumn = column;
+                    lastRunStartIndex = currentCharIndex;
+                    lastRunFontWidthMismatch = fontWidthMismatch;
+                }
+                measuredWidthForRun += measuredCodePointWidth;
+                column += codePointWcWidth;
+                currentCharIndex += charsForCodePoint;
+                while (currentCharIndex < charsUsedInLine && WcWidth.width(line, currentCharIndex) <= 0) {
+                    // Eat combining chars so that they are treated as part of the last non-combining code point,
+                    // instead of e.g. being considered inside the cursor in the next run.
+                    currentCharIndex += Character.isHighSurrogate(line[currentCharIndex]) ? 2 : 1;
+                }
+            }
+
+            final int columnWidthSinceLastRun = columns - lastRunStartColumn;
+            final int charsSinceLastRun = currentCharIndex - lastRunStartIndex;
+            int cursorColor = lastRunInsideCursor ? mEmulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR] : 0;
+            boolean invertCursorTextColor = false;
+            if (lastRunInsideCursor && cursorShape == TerminalEmulator.TERMINAL_CURSOR_STYLE_BLOCK) {
+                invertCursorTextColor = true;
+            }
+            drawTextRun(canvas, line, palette, heightOffset, lastRunStartColumn, columnWidthSinceLastRun, lastRunStartIndex, charsSinceLastRun,
+                measuredWidthForRun, cursorColor, cursorShape, lastRunStyle, reverseVideo || invertCursorTextColor || lastRunInsideSelection);
+        }
+    }
+
+    private void drawTextRun(Canvas canvas, char[] text, int[] palette, float y, int startColumn, int runWidthColumns,
+                             int startCharIndex, int runWidthChars, float mes, int cursor, int cursorStyle,
+                             long textStyle, boolean reverseVideo) {
+        int foreColor = TextStyle.decodeForeColor(textStyle);
+        final int effect = TextStyle.decodeEffect(textStyle);
+        int backColor = TextStyle.decodeBackColor(textStyle);
+        final boolean bold = (effect & (TextStyle.CHARACTER_ATTRIBUTE_BOLD | TextStyle.CHARACTER_ATTRIBUTE_BLINK)) != 0;
+        final boolean underline = (effect & TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE) != 0;
+        final boolean italic = (effect & TextStyle.CHARACTER_ATTRIBUTE_ITALIC) != 0;
+        final boolean strikeThrough = (effect & TextStyle.CHARACTER_ATTRIBUTE_STRIKETHROUGH) != 0;
+        final boolean dim = (effect & TextStyle.CHARACTER_ATTRIBUTE_DIM) != 0;
+
+        if ((foreColor & 0xff000000) != 0xff000000) {
+            // Let bold have bright colors if applicable (one of the first 8):
+            if (bold && foreColor >= 0 && foreColor < 8) foreColor += 8;
+            foreColor = palette[foreColor];
+        }
+
+        if ((backColor & 0xff000000) != 0xff000000) {
+            backColor = palette[backColor];
+        }
+
+        // Reverse video here if _one and only one_ of the reverse flags are set:
+        final boolean reverseVideoHere = reverseVideo ^ (effect & (TextStyle.CHARACTER_ATTRIBUTE_INVERSE)) != 0;
+        if (reverseVideoHere) {
+            int tmp = foreColor;
+            foreColor = backColor;
+            backColor = tmp;
+        }
+
+        float left = startColumn * mFontWidth;
+        float right = left + runWidthColumns * mFontWidth;
+
+        mes = mes / mFontWidth;
+        boolean savedMatrix = false;
+        if (Math.abs(mes - runWidthColumns) > 0.01) {
+            canvas.save();
+            canvas.scale(runWidthColumns / mes, 1.f);
+            left *= mes / runWidthColumns;
+            right *= mes / runWidthColumns;
+            savedMatrix = true;
+        }
+
+        if (backColor != palette[TextStyle.COLOR_INDEX_BACKGROUND]) {
+            // Only draw non-default background.
+            mTextPaint.setColor(backColor);
+            canvas.drawRect(left, y - mFontLineSpacingAndAscent + mFontAscent, right, y, mTextPaint);
+        }
+
+        if (cursor != 0) {
+            mTextPaint.setColor(cursor);
+            float cursorHeight = mFontLineSpacingAndAscent - mFontAscent;
+            if (cursorStyle == TerminalEmulator.TERMINAL_CURSOR_STYLE_UNDERLINE) cursorHeight /= 4.;
+            else if (cursorStyle == TerminalEmulator.TERMINAL_CURSOR_STYLE_BAR) right -= ((right - left) * 3) / 4.;
+            canvas.drawRect(left, y - cursorHeight, right, y, mTextPaint);
+        }
+
+        if ((effect & TextStyle.CHARACTER_ATTRIBUTE_INVISIBLE) == 0) {
+            if (dim) {
+                int red = (0xFF & (foreColor >> 16));
+                int green = (0xFF & (foreColor >> 8));
+                int blue = (0xFF & foreColor);
+                // Dim color handling used by libvte which in turn took it from xterm
+                // (https://bug735245.bugzilla-attachments.gnome.org/attachment.cgi?id=284267):
+                red = red * 2 / 3;
+                green = green * 2 / 3;
+                blue = blue * 2 / 3;
+                foreColor = 0xFF000000 + (red << 16) + (green << 8) + blue;
+            }
+
+            mTextPaint.setFakeBoldText(bold);
+            mTextPaint.setUnderlineText(underline);
+            mTextPaint.setTextSkewX(italic ? -0.35f : 0.f);
+            mTextPaint.setStrikeThruText(strikeThrough);
+            mTextPaint.setColor(foreColor);
+
+            // The text alignment is the default Paint.Align.LEFT.
+            canvas.drawTextRun(text, startCharIndex, runWidthChars, startCharIndex, runWidthChars, left, y - mFontLineSpacingAndAscent, false, mTextPaint);
+        }
+
+        if (savedMatrix) canvas.restore();
+    }
+
+    public float getFontWidth() {
+        return mFontWidth;
+    }
+
+    public int getFontLineSpacing() {
+        return mFontLineSpacing;
+    }
+}

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -1,0 +1,1500 @@
+package com.termux.view;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Typeface;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.ActionMode;
+import android.view.HapticFeedbackConstants;
+import android.view.InputDevice;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewTreeObserver;
+import android.view.accessibility.AccessibilityManager;
+import android.view.autofill.AutofillManager;
+import android.view.autofill.AutofillValue;
+import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.widget.Scroller;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import com.termux.terminal.KeyHandler;
+import com.termux.terminal.TerminalEmulator;
+import com.termux.terminal.TerminalSession;
+import com.termux.view.textselection.TextSelectionCursorController;
+
+/** View displaying and interacting with a {@link TerminalSession}. */
+public final class TerminalView extends View {
+
+    /** Log terminal view key and IME events. */
+    private static boolean TERMINAL_VIEW_KEY_LOGGING_ENABLED = false;
+
+    /** The currently displayed terminal session, whose emulator is {@link #mEmulator}. */
+    public TerminalSession mTermSession;
+    /** Our terminal emulator whose session is {@link #mTermSession}. */
+    public TerminalEmulator mEmulator;
+
+    public TerminalRenderer mRenderer;
+
+    public TerminalViewClient mClient;
+
+    private TextSelectionCursorController mTextSelectionCursorController;
+
+    private Handler mTerminalCursorBlinkerHandler;
+    private TerminalCursorBlinkerRunnable mTerminalCursorBlinkerRunnable;
+    private int mTerminalCursorBlinkerRate;
+    private boolean mCursorInvisibleIgnoreOnce;
+    public static final int TERMINAL_CURSOR_BLINK_RATE_MIN = 100;
+    public static final int TERMINAL_CURSOR_BLINK_RATE_MAX = 2000;
+
+    /** The top row of text to display. Ranges from -activeTranscriptRows to 0. */
+    int mTopRow;
+    int[] mDefaultSelectors = new int[]{-1,-1,-1,-1};
+
+    float mScaleFactor = 1.f;
+    final GestureAndScaleRecognizer mGestureRecognizer;
+
+    /** Keep track of where mouse touch event started which we report as mouse scroll. */
+    private int mMouseScrollStartX = -1, mMouseScrollStartY = -1;
+    /** Keep track of the time when a touch event leading to sending mouse scroll events started. */
+    private long mMouseStartDownTime = -1;
+
+    final Scroller mScroller;
+
+    /** What was left in from scrolling movement. */
+    float mScrollRemainder;
+
+    /** If non-zero, this is the last unicode code point received if that was a combining character. */
+    int mCombiningAccent;
+
+    /**
+     * The current AutoFill type returned for {@link View#getAutofillType()} by {@link #getAutofillType()}.
+     *
+     * The default is {@link #AUTOFILL_TYPE_NONE} so that AutoFill UI, like toolbar above keyboard
+     * is not shown automatically, like on Activity starts/View create. This value should be updated
+     * to required value, like {@link #AUTOFILL_TYPE_TEXT} before calling
+     * {@link AutofillManager#requestAutofill(View)} so that AutoFill UI shows. The updated value
+     * set will automatically be restored to {@link #AUTOFILL_TYPE_NONE} in
+     * {@link #autofill(AutofillValue)} so that AutoFill UI isn't shown anymore by calling
+     * {@link #resetAutoFill()}.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private int mAutoFillType = AUTOFILL_TYPE_NONE;
+
+    /**
+     * The current AutoFill type returned for {@link View#getImportantForAutofill()} by
+     * {@link #getImportantForAutofill()}.
+     *
+     * The default is {@link #IMPORTANT_FOR_AUTOFILL_NO} so that view is not considered important
+     * for AutoFill. This value should be updated to required value, like
+     * {@link #IMPORTANT_FOR_AUTOFILL_YES} before calling {@link AutofillManager#requestAutofill(View)}
+     * so that Android and apps consider the view as important for AutoFill to process the request.
+     * The updated value set will automatically be restored to {@link #IMPORTANT_FOR_AUTOFILL_NO} in
+     * {@link #autofill(AutofillValue)} by calling {@link #resetAutoFill()}.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private int mAutoFillImportance = IMPORTANT_FOR_AUTOFILL_NO;
+
+    /**
+     * The current AutoFill hints returned for {@link View#getAutofillHints()} ()} by {@link #getAutofillHints()} ()}.
+     *
+     * The default is an empty `string[]`. This value should be updated to required value. The
+     * updated value set will automatically be restored an empty `string[]` in
+     * {@link #autofill(AutofillValue)} by calling {@link #resetAutoFill()}.
+     */
+    private String[] mAutoFillHints = new String[0];
+
+    private final boolean mAccessibilityEnabled;
+
+    /** The {@link KeyEvent} is generated from a virtual keyboard, like manually with the {@link KeyEvent#KeyEvent(int, int)} constructor. */
+    public final static int KEY_EVENT_SOURCE_VIRTUAL_KEYBOARD = KeyCharacterMap.VIRTUAL_KEYBOARD; // -1
+
+    /** The {@link KeyEvent} is generated from a non-physical device, like if 0 value is returned by {@link KeyEvent#getDeviceId()}. */
+    public final static int KEY_EVENT_SOURCE_SOFT_KEYBOARD = 0;
+
+    private static final String LOG_TAG = "TerminalView";
+
+    public TerminalView(Context context, AttributeSet attributes) { // NO_UCD (unused code)
+        super(context, attributes);
+        mGestureRecognizer = new GestureAndScaleRecognizer(context, new GestureAndScaleRecognizer.Listener() {
+
+            boolean scrolledWithFinger;
+
+            @Override
+            public boolean onUp(MotionEvent event) {
+                mScrollRemainder = 0.0f;
+                if (mEmulator != null && mEmulator.isMouseTrackingActive() && !event.isFromSource(InputDevice.SOURCE_MOUSE) && !isSelectingText() && !scrolledWithFinger) {
+                    // Quick event processing when mouse tracking is active - do not wait for check of double tapping
+                    // for zooming.
+                    sendMouseEventCode(event, TerminalEmulator.MOUSE_LEFT_BUTTON, true);
+                    sendMouseEventCode(event, TerminalEmulator.MOUSE_LEFT_BUTTON, false);
+                    return true;
+                }
+                scrolledWithFinger = false;
+                return false;
+            }
+
+            @Override
+            public boolean onSingleTapUp(MotionEvent event) {
+                if (mEmulator == null) return true;
+
+                if (isSelectingText()) {
+                    stopTextSelectionMode();
+                    return true;
+                }
+                requestFocus();
+                mClient.onSingleTapUp(event);
+                return true;
+            }
+
+            @Override
+            public boolean onScroll(MotionEvent e, float distanceX, float distanceY) {
+                if (mEmulator == null) return true;
+                if (mEmulator.isMouseTrackingActive() && e.isFromSource(InputDevice.SOURCE_MOUSE)) {
+                    // If moving with mouse pointer while pressing button, report that instead of scroll.
+                    // This means that we never report moving with button press-events for touch input,
+                    // since we cannot just start sending these events without a starting press event,
+                    // which we do not do for touch input, only mouse in onTouchEvent().
+                    sendMouseEventCode(e, TerminalEmulator.MOUSE_LEFT_BUTTON_MOVED, true);
+                } else {
+                    scrolledWithFinger = true;
+                    distanceY += mScrollRemainder;
+                    int deltaRows = (int) (distanceY / mRenderer.mFontLineSpacing);
+                    mScrollRemainder = distanceY - deltaRows * mRenderer.mFontLineSpacing;
+                    doScroll(e, deltaRows);
+                }
+                return true;
+            }
+
+            @Override
+            public boolean onScale(float focusX, float focusY, float scale) {
+                if (mEmulator == null || isSelectingText()) return true;
+                mScaleFactor *= scale;
+                mScaleFactor = mClient.onScale(mScaleFactor);
+                return true;
+            }
+
+            @Override
+            public boolean onFling(final MotionEvent e2, float velocityX, float velocityY) {
+                if (mEmulator == null) return true;
+                // Do not start scrolling until last fling has been taken care of:
+                if (!mScroller.isFinished()) return true;
+
+                final boolean mouseTrackingAtStartOfFling = mEmulator.isMouseTrackingActive();
+                float SCALE = 0.25f;
+                if (mouseTrackingAtStartOfFling) {
+                    mScroller.fling(0, 0, 0, -(int) (velocityY * SCALE), 0, 0, -mEmulator.mRows / 2, mEmulator.mRows / 2);
+                } else {
+                    mScroller.fling(0, mTopRow, 0, -(int) (velocityY * SCALE), 0, 0, -mEmulator.getScreen().getActiveTranscriptRows(), 0);
+                }
+
+                post(new Runnable() {
+                    private int mLastY = 0;
+
+                    @Override
+                    public void run() {
+                        if (mouseTrackingAtStartOfFling != mEmulator.isMouseTrackingActive()) {
+                            mScroller.abortAnimation();
+                            return;
+                        }
+                        if (mScroller.isFinished()) return;
+                        boolean more = mScroller.computeScrollOffset();
+                        int newY = mScroller.getCurrY();
+                        int diff = mouseTrackingAtStartOfFling ? (newY - mLastY) : (newY - mTopRow);
+                        doScroll(e2, diff);
+                        mLastY = newY;
+                        if (more) post(this);
+                    }
+                });
+
+                return true;
+            }
+
+            @Override
+            public boolean onDown(float x, float y) {
+                // Why is true not returned here?
+                // https://developer.android.com/training/gestures/detector.html#detect-a-subset-of-supported-gestures
+                // Although setting this to true still does not solve the following errors when long pressing in terminal view text area
+                // ViewDragHelper: Ignoring pointerId=0 because ACTION_DOWN was not received for this pointer before ACTION_MOVE
+                // Commenting out the call to mGestureDetector.onTouchEvent(event) in GestureAndScaleRecognizer#onTouchEvent() removes
+                // the error logging, so issue is related to GestureDetector
+                return false;
+            }
+
+            @Override
+            public boolean onDoubleTap(MotionEvent event) {
+                // Do not treat is as a single confirmed tap - it may be followed by zoom.
+                return false;
+            }
+
+            @Override
+            public void onLongPress(MotionEvent event) {
+                if (mGestureRecognizer.isInProgress()) return;
+                if (mClient.onLongPress(event)) return;
+                if (!isSelectingText()) {
+                    performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                    startTextSelectionMode(event);
+                }
+            }
+        });
+        mScroller = new Scroller(context);
+        AccessibilityManager am = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+        mAccessibilityEnabled = am.isEnabled();
+    }
+
+
+
+    /**
+     * @param client The {@link TerminalViewClient} interface implementation to allow
+     *                           for communication between {@link TerminalView} and its client.
+     */
+    public void setTerminalViewClient(TerminalViewClient client) {
+        this.mClient = client;
+    }
+
+    /**
+     * Sets whether terminal view key logging is enabled or not.
+     *
+     * @param value The boolean value that defines the state.
+     */
+    public void setIsTerminalViewKeyLoggingEnabled(boolean value) {
+        TERMINAL_VIEW_KEY_LOGGING_ENABLED = value;
+    }
+
+
+
+    /**
+     * Attach a {@link TerminalSession} to this view.
+     *
+     * @param session The {@link TerminalSession} this view will be displaying.
+     */
+    public boolean attachSession(TerminalSession session) {
+        if (session == mTermSession) return false;
+        mTopRow = 0;
+
+        mTermSession = session;
+        mEmulator = null;
+        mCombiningAccent = 0;
+
+        updateSize();
+
+        // Wait with enabling the scrollbar until we have a terminal to get scroll position from.
+        setVerticalScrollBarEnabled(true);
+
+        return true;
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        // Ensure that inputType is only set if TerminalView is selected view with the keyboard and
+        // an alternate view is not selected, like an EditText. This is necessary if an activity is
+        // initially started with the alternate view or if activity is returned to from another app
+        // and the alternate view was the one selected the last time.
+        if (mClient.isTerminalViewSelected()) {
+            if (mClient.shouldEnforceCharBasedInput()) {
+                // Some keyboards seems do not reset the internal state on TYPE_NULL.
+                // Affects mostly Samsung stock keyboards.
+                // https://github.com/termux/termux-app/issues/686
+                // However, this is not a valid value as per AOSP since `InputType.TYPE_CLASS_*` is
+                // not set and it logs a warning:
+                // W/InputAttributes: Unexpected input class: inputType=0x00080090 imeOptions=0x02000000
+                // https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:packages/inputmethods/LatinIME/java/src/com/android/inputmethod/latin/InputAttributes.java;l=79
+                outAttrs.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+            } else {
+                // Using InputType.NULL is the most correct input type and avoids issues with other hacks.
+                //
+                // Previous keyboard issues:
+                // https://github.com/termux/termux-packages/issues/25
+                // https://github.com/termux/termux-app/issues/87.
+                // https://github.com/termux/termux-app/issues/126.
+                // https://github.com/termux/termux-app/issues/137 (japanese chars and TYPE_NULL).
+                outAttrs.inputType = InputType.TYPE_NULL;
+            }
+        } else {
+            // Corresponds to android:inputType="text"
+            outAttrs.inputType =  InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL;
+        }
+
+        // Note that IME_ACTION_NONE cannot be used as that makes it impossible to input newlines using the on-screen
+        // keyboard on Android TV (see https://github.com/termux/termux-app/issues/221).
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN;
+
+        return new BaseInputConnection(this, true) {
+
+            @Override
+            public boolean finishComposingText() {
+                if (TERMINAL_VIEW_KEY_LOGGING_ENABLED) mClient.logInfo(LOG_TAG, "IME: finishComposingText()");
+                super.finishComposingText();
+
+                sendTextToTerminal(getEditable());
+                getEditable().clear();
+                return true;
+            }
+
+            @Override
+            public boolean commitText(CharSequence text, int newCursorPosition) {
+                if (TERMINAL_VIEW_KEY_LOGGING_ENABLED) {
+                    mClient.logInfo(LOG_TAG, "IME: commitText(\"" + text + "\", " + newCursorPosition + ")");
+                }
+                super.commitText(text, newCursorPosition);
+
+                if (mEmulator == null) return true;
+
+                Editable content = getEditable();
+                sendTextToTerminal(content);
+                content.clear();
+                return true;
+            }
+
+            @Override
+            public boolean deleteSurroundingText(int leftLength, int rightLength) {
+                if (TERMINAL_VIEW_KEY_LOGGING_ENABLED) {
+                    mClient.logInfo(LOG_TAG, "IME: deleteSurroundingText(" + leftLength + ", " + rightLength + ")");
+                }
+                // The stock Samsung keyboard with 'Auto check spelling' enabled sends leftLength > 1.
+                KeyEvent deleteKey = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL);
+                for (int i = 0; i < leftLength; i++) sendKeyEvent(deleteKey);
+                return super.deleteSurroundingText(leftLength, rightLength);
+            }
+
+            void sendTextToTerminal(CharSequence text) {
+                stopTextSelectionMode();
+                final int textLengthInChars = text.length();
+                for (int i = 0; i < textLengthInChars; i++) {
+                    char firstChar = text.charAt(i);
+                    int codePoint;
+                    if (Character.isHighSurrogate(firstChar)) {
+                        if (++i < textLengthInChars) {
+                            codePoint = Character.toCodePoint(firstChar, text.charAt(i));
+                        } else {
+                            // At end of string, with no low surrogate following the high:
+                            codePoint = TerminalEmulator.UNICODE_REPLACEMENT_CHAR;
+                        }
+                    } else {
+                        codePoint = firstChar;
+                    }
+
+                    // Check onKeyDown() for details.
+                    if (mClient.readShiftKey())
+                        codePoint = Character.toUpperCase(codePoint);
+
+                    boolean ctrlHeld = false;
+                    if (codePoint <= 31 && codePoint != 27) {
+                        if (codePoint == '\n') {
+                            // The AOSP keyboard and descendants seems to send \n as text when the enter key is pressed,
+                            // instead of a key event like most other keyboard apps. A terminal expects \r for the enter
+                            // key (although when icrnl is enabled this doesn't make a difference - run 'stty -icrnl' to
+                            // check the behaviour).
+                            codePoint = '\r';
+                        }
+
+                        // E.g. penti keyboard for ctrl input.
+                        ctrlHeld = true;
+                        switch (codePoint) {
+                            case 31:
+                                codePoint = '_';
+                                break;
+                            case 30:
+                                codePoint = '^';
+                                break;
+                            case 29:
+                                codePoint = ']';
+                                break;
+                            case 28:
+                                codePoint = '\\';
+                                break;
+                            default:
+                                codePoint += 96;
+                                break;
+                        }
+                    }
+
+                    inputCodePoint(KEY_EVENT_SOURCE_SOFT_KEYBOARD, codePoint, ctrlHeld, false);
+                }
+            }
+
+        };
+    }
+
+    @Override
+    protected int computeVerticalScrollRange() {
+        return mEmulator == null ? 1 : mEmulator.getScreen().getActiveRows();
+    }
+
+    @Override
+    protected int computeVerticalScrollExtent() {
+        return mEmulator == null ? 1 : mEmulator.mRows;
+    }
+
+    @Override
+    protected int computeVerticalScrollOffset() {
+        return mEmulator == null ? 1 : mEmulator.getScreen().getActiveRows() + mTopRow - mEmulator.mRows;
+    }
+
+    public void onScreenUpdated() {
+        onScreenUpdated(false);
+    }
+
+    public void onScreenUpdated(boolean skipScrolling) {
+        if (mEmulator == null) return;
+
+        int rowsInHistory = mEmulator.getScreen().getActiveTranscriptRows();
+        if (mTopRow < -rowsInHistory) mTopRow = -rowsInHistory;
+
+        if (isSelectingText() || mEmulator.isAutoScrollDisabled()) {
+
+            // Do not scroll when selecting text.
+            int rowShift = mEmulator.getScrollCounter();
+            if (-mTopRow + rowShift > rowsInHistory) {
+                // .. unless we're hitting the end of history transcript, in which
+                // case we abort text selection and scroll to end.
+                if (isSelectingText())
+                    stopTextSelectionMode();
+
+                if (mEmulator.isAutoScrollDisabled()) {
+                    mTopRow = -rowsInHistory;
+                    skipScrolling = true;
+                }
+            } else {
+                skipScrolling = true;
+                mTopRow -= rowShift;
+                decrementYTextSelectionCursors(rowShift);
+            }
+        }
+
+        if (!skipScrolling && mTopRow != 0) {
+            // Scroll down if not already there.
+            if (mTopRow < -3) {
+                // Awaken scroll bars only if scrolling a noticeable amount
+                // - we do not want visible scroll bars during normal typing
+                // of one row at a time.
+                awakenScrollBars();
+            }
+            mTopRow = 0;
+        }
+
+        mEmulator.clearScrollCounter();
+
+        invalidate();
+        if (mAccessibilityEnabled) setContentDescription(getText());
+    }
+
+    /** This must be called by the hosting activity in {@link Activity#onContextMenuClosed(Menu)}
+     * when context menu for the {@link TerminalView} is started by
+     * {@link TextSelectionCursorController#ACTION_MORE} is closed. */
+    public void onContextMenuClosed(Menu menu) {
+        // Unset the stored text since it shouldn't be used anymore and should be cleared from memory
+        unsetStoredSelectedText();
+    }
+
+    /**
+     * Sets the text size, which in turn sets the number of rows and columns.
+     *
+     * @param textSize the new font size, in density-independent pixels.
+     */
+    public void setTextSize(int textSize) {
+        mRenderer = new TerminalRenderer(textSize, mRenderer == null ? Typeface.MONOSPACE : mRenderer.mTypeface);
+        updateSize();
+    }
+
+    public void setTypeface(Typeface newTypeface) {
+        mRenderer = new TerminalRenderer(mRenderer.mTextSize, newTypeface);
+        updateSize();
+        invalidate();
+    }
+
+    @Override
+    public boolean onCheckIsTextEditor() {
+        return true;
+    }
+
+    @Override
+    public boolean isOpaque() {
+        return true;
+    }
+
+    /**
+     * Get the zero indexed column and row of the terminal view for the
+     * position of the event.
+     *
+     * @param event The event with the position to get the column and row for.
+     * @param relativeToScroll If true the column number will take the scroll
+     * position into account. E.g. if scrolled 3 lines up and the event
+     * position is in the top left, column will be -3 if relativeToScroll is
+     * true and 0 if relativeToScroll is false.
+     * @return Array with the column and row.
+     */
+    public int[] getColumnAndRow(MotionEvent event, boolean relativeToScroll) {
+        int column = (int) (event.getX() / mRenderer.mFontWidth);
+        int row = (int) ((event.getY() - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
+        if (relativeToScroll) {
+            row += mTopRow;
+        }
+        return new int[] { column, row };
+    }
+
+    /** Send a single mouse event code to the terminal. */
+    void sendMouseEventCode(MotionEvent e, int button, boolean pressed) {
+        int[] columnAndRow = getColumnAndRow(e, false);
+        int x = columnAndRow[0] + 1;
+        int y = columnAndRow[1] + 1;
+        if (pressed && (button == TerminalEmulator.MOUSE_WHEELDOWN_BUTTON || button == TerminalEmulator.MOUSE_WHEELUP_BUTTON)) {
+            if (mMouseStartDownTime == e.getDownTime()) {
+                x = mMouseScrollStartX;
+                y = mMouseScrollStartY;
+            } else {
+                mMouseStartDownTime = e.getDownTime();
+                mMouseScrollStartX = x;
+                mMouseScrollStartY = y;
+            }
+        }
+        mEmulator.sendMouseEvent(button, x, y, pressed);
+    }
+
+    /** Perform a scroll, either from dragging the screen or by scrolling a mouse wheel. */
+    void doScroll(MotionEvent event, int rowsDown) {
+        boolean up = rowsDown < 0;
+        int amount = Math.abs(rowsDown);
+        for (int i = 0; i < amount; i++) {
+            if (mEmulator.isMouseTrackingActive()) {
+                sendMouseEventCode(event, up ? TerminalEmulator.MOUSE_WHEELUP_BUTTON : TerminalEmulator.MOUSE_WHEELDOWN_BUTTON, true);
+            } else if (mEmulator.isAlternateBufferActive()) {
+                // Send up and down key events for scrolling, which is what some terminals do to make scroll work in
+                // e.g. less, which shifts to the alt screen without mouse handling.
+                handleKeyCode(up ? KeyEvent.KEYCODE_DPAD_UP : KeyEvent.KEYCODE_DPAD_DOWN, 0);
+            } else {
+                mTopRow = Math.min(0, Math.max(-(mEmulator.getScreen().getActiveTranscriptRows()), mTopRow + (up ? -1 : 1)));
+                if (!awakenScrollBars()) invalidate();
+            }
+        }
+    }
+
+    /** Overriding {@link View#onGenericMotionEvent(MotionEvent)}. */
+    @Override
+    public boolean onGenericMotionEvent(MotionEvent event) {
+        if (mEmulator != null && event.isFromSource(InputDevice.SOURCE_MOUSE) && event.getAction() == MotionEvent.ACTION_SCROLL) {
+            // Handle mouse wheel scrolling.
+            boolean up = event.getAxisValue(MotionEvent.AXIS_VSCROLL) > 0.0f;
+            doScroll(event, up ? -3 : 3);
+            return true;
+        }
+        return false;
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    @TargetApi(23)
+    public boolean onTouchEvent(MotionEvent event) {
+        if (mEmulator == null) return true;
+        final int action = event.getAction();
+
+        if (isSelectingText()) {
+            updateFloatingToolbarVisibility(event);
+            mGestureRecognizer.onTouchEvent(event);
+            return true;
+        } else if (event.isFromSource(InputDevice.SOURCE_MOUSE)) {
+            if (event.isButtonPressed(MotionEvent.BUTTON_SECONDARY)) {
+                if (action == MotionEvent.ACTION_DOWN) showContextMenu();
+                return true;
+            } else if (event.isButtonPressed(MotionEvent.BUTTON_TERTIARY)) {
+                ClipboardManager clipboardManager = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+                ClipData clipData = clipboardManager.getPrimaryClip();
+                if (clipData != null) {
+                    ClipData.Item clipItem = clipData.getItemAt(0);
+                    if (clipItem != null) {
+                        CharSequence text = clipItem.coerceToText(getContext());
+                        if (!TextUtils.isEmpty(text)) mEmulator.paste(text.toString());
+                    }
+                }
+            } else if (mEmulator.isMouseTrackingActive()) { // BUTTON_PRIMARY.
+                switch (event.getAction()) {
+                    case MotionEvent.ACTION_DOWN:
+                    case MotionEvent.ACTION_UP:
+                        sendMouseEventCode(event, TerminalEmulator.MOUSE_LEFT_BUTTON, event.getAction() == MotionEvent.ACTION_DOWN);
+                        break;
+                    case MotionEvent.ACTION_MOVE:
+                        sendMouseEventCode(event, TerminalEmulator.MOUSE_LEFT_BUTTON_MOVED, true);
+                        break;
+                }
+            }
+        }
+
+        mGestureRecognizer.onTouchEvent(event);
+        return true;
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
+            mClient.logInfo(LOG_TAG, "onKeyPreIme(keyCode=" + keyCode + ", event=" + event + ")");
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            cancelRequestAutoFill();
+            if (isSelectingText()) {
+                stopTextSelectionMode();
+                return true;
+            } else if (mClient.shouldBackButtonBeMappedToEscape()) {
+                // Intercept back button to treat it as escape:
+                switch (event.getAction()) {
+                    case KeyEvent.ACTION_DOWN:
+                        return onKeyDown(keyCode, event);
+                    case KeyEvent.ACTION_UP:
+                        return onKeyUp(keyCode, event);
+                }
+            }
+        } else if (mClient.shouldUseCtrlSpaceWorkaround() &&
+                   keyCode == KeyEvent.KEYCODE_SPACE && event.isCtrlPressed()) {
+            /* ctrl+space does not work on some ROMs without this workaround.
+               However, this breaks it on devices where it works out of the box. */
+            return onKeyDown(keyCode, event);
+        }
+        return super.onKeyPreIme(keyCode, event);
+    }
+
+    /**
+     * Key presses in software keyboards will generally NOT trigger this listener, although some
+     * may elect to do so in some situations. Do not rely on this to catch software key presses.
+     * Gboard calls this when shouldEnforceCharBasedInput() is disabled (InputType.TYPE_NULL) instead
+     * of calling commitText(), with deviceId=-1. However, Hacker's Keyboard, OpenBoard, LG Keyboard
+     * call commitText().
+     *
+     * This function may also be called directly without android calling it, like by
+     * `TerminalExtraKeys` which generates a KeyEvent manually which uses {@link KeyCharacterMap#VIRTUAL_KEYBOARD}
+     * as the device (deviceId=-1), as does Gboard. That would normally use mappings defined in
+     * `/system/usr/keychars/Virtual.kcm`. You can run `dumpsys input` to find the `KeyCharacterMapFile`
+     * used by virtual keyboard or hardware keyboard. Note that virtual keyboard device is not the
+     * same as software keyboard, like Gboard, etc. Its a fake device used for generating events and
+     * for testing.
+     *
+     * We handle shift key in `commitText()` to convert codepoint to uppercase case there with a
+     * call to {@link Character#toUpperCase(int)}, but here we instead rely on getUnicodeChar() for
+     * conversion of keyCode, for both hardware keyboard shift key (via effectiveMetaState) and
+     * `mClient.readShiftKey()`, based on value in kcm files.
+     * This may result in different behaviour depending on keyboard and android kcm files set for the
+     * InputDevice for the event passed to this function. This will likely be an issue for non-english
+     * languages since `Virtual.kcm` in english only by default or at least in AOSP. For both hardware
+     * shift key (via effectiveMetaState) and `mClient.readShiftKey()`, `getUnicodeChar()` is used
+     * for shift specific behaviour which usually is to uppercase.
+     *
+     * For fn key on hardware keyboard, android checks kcm files for hardware keyboards, which is
+     * `Generic.kcm` by default, unless a vendor specific one is defined. The event passed will have
+     * {@link KeyEvent#META_FUNCTION_ON} set. If the kcm file only defines a single character or unicode
+     * code point `\\uxxxx`, then only one event is passed with that value. However, if kcm defines
+     * a `fallback` key for fn or others, like `key DPAD_UP { ... fn: fallback PAGE_UP }`, then
+     * android will first pass an event with original key `DPAD_UP` and {@link KeyEvent#META_FUNCTION_ON}
+     * set. But this function will not consume it and android will pass another event with `PAGE_UP`
+     * and {@link KeyEvent#META_FUNCTION_ON} not set, which will be consumed.
+     *
+     * Now there are some other issues as well, firstly ctrl and alt flags are not passed to
+     * `getUnicodeChar()`, so modified key values in kcm are not used. Secondly, if the kcm file
+     * for other modifiers like shift or fn define a non-alphabet, like { fn: '\u0015' } to act as
+     * DPAD_LEFT, the `getUnicodeChar()` will correctly return `21` as the code point but action will
+     * not happen because the `handleKeyCode()` function that transforms DPAD_LEFT to `\033[D`
+     * escape sequence for the terminal to perform the left action would not be called since its
+     * called before `getUnicodeChar()` and terminal will instead get `21 0x15 Negative Acknowledgement`.
+     * The solution to such issues is calling `getUnicodeChar()` before the call to `handleKeyCode()`
+     * if user has defined a custom kcm file, like done in POC mentioned in #2237. Note that
+     * Hacker's Keyboard calls `commitText()` so don't test fn/shift with it for this function.
+     * https://github.com/termux/termux-app/pull/2237
+     * https://github.com/agnostic-apollo/termux-app/blob/terminal-code-point-custom-mapping/terminal-view/src/main/java/com/termux/view/TerminalView.java
+     *
+     * Key Character Map (kcm) and Key Layout (kl) files info:
+     * https://source.android.com/devices/input/key-character-map-files
+     * https://source.android.com/devices/input/key-layout-files
+     * https://source.android.com/devices/input/keyboard-devices
+     * AOSP kcm and kl files:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/data/keyboards
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/packages/InputDevices/res/raw
+     *
+     * KeyCodes:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/core/java/android/view/KeyEvent.java
+     * https://cs.android.com/android/platform/superproject/+/master:frameworks/native/include/android/keycodes.h
+     *
+     * `dumpsys input`:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/services/inputflinger/reader/EventHub.cpp;l=1917
+     *
+     * Loading of keymap:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/services/inputflinger/reader/EventHub.cpp;l=1644
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/libs/input/Keyboard.cpp;l=41
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/libs/input/InputDevice.cpp
+     * OVERLAY keymaps for hardware keyboards may be combined as well:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/libs/input/KeyCharacterMap.cpp;l=165
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/libs/input/KeyCharacterMap.cpp;l=831
+     *
+     * Parse kcm file:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/libs/input/KeyCharacterMap.cpp;l=727
+     * Parse key value:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/libs/input/KeyCharacterMap.cpp;l=981
+     *
+     * `KeyEvent.getUnicodeChar()`
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/core/java/android/view/KeyEvent.java;l=2716
+     * https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/KeyCharacterMap.java;l=368
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/core/jni/android_view_KeyCharacterMap.cpp;l=117
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/libs/input/KeyCharacterMap.cpp;l=231
+     *
+     * Keyboard layouts advertised by applications, like for hardware keyboards via #ACTION_QUERY_KEYBOARD_LAYOUTS
+     * Config is stored in `/data/system/input-manager-state.xml`
+     * https://github.com/ris58h/custom-keyboard-layout
+     * Loading from apps:
+     * https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/input/InputManagerService.java;l=1221
+     * Set:
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/core/java/android/hardware/input/InputManager.java;l=89
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/core/java/android/hardware/input/InputManager.java;l=543
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:packages/apps/Settings/src/com/android/settings/inputmethod/KeyboardLayoutDialogFragment.java;l=167
+     * https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/input/InputManagerService.java;l=1385
+     * https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/input/PersistentDataStore.java
+     * Get overlay keyboard layout
+     * https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/input/InputManagerService.java;l=2158
+     * https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/services/core/jni/com_android_server_input_InputManagerService.cpp;l=616
+     */
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
+            mClient.logInfo(LOG_TAG, "onKeyDown(keyCode=" + keyCode + ", isSystem()=" + event.isSystem() + ", event=" + event + ")");
+        if (mEmulator == null) return true;
+        if (isSelectingText()) {
+            stopTextSelectionMode();
+        }
+
+        if (mClient.onKeyDown(keyCode, event, mTermSession)) {
+            invalidate();
+            return true;
+        } else if (event.isSystem() && (!mClient.shouldBackButtonBeMappedToEscape() || keyCode != KeyEvent.KEYCODE_BACK)) {
+            return super.onKeyDown(keyCode, event);
+        } else if (event.getAction() == KeyEvent.ACTION_MULTIPLE && keyCode == KeyEvent.KEYCODE_UNKNOWN) {
+            mTermSession.write(event.getCharacters());
+            return true;
+        } else if (keyCode == KeyEvent.KEYCODE_LANGUAGE_SWITCH) {
+            return super.onKeyDown(keyCode, event);
+        }
+
+        final int metaState = event.getMetaState();
+        final boolean controlDown = event.isCtrlPressed() || mClient.readControlKey();
+        final boolean leftAltDown = (metaState & KeyEvent.META_ALT_LEFT_ON) != 0 || mClient.readAltKey();
+        final boolean shiftDown = event.isShiftPressed() || mClient.readShiftKey();
+        final boolean rightAltDownFromEvent = (metaState & KeyEvent.META_ALT_RIGHT_ON) != 0;
+
+        int keyMod = 0;
+        if (controlDown) keyMod |= KeyHandler.KEYMOD_CTRL;
+        if (event.isAltPressed() || leftAltDown) keyMod |= KeyHandler.KEYMOD_ALT;
+        if (shiftDown) keyMod |= KeyHandler.KEYMOD_SHIFT;
+        if (event.isNumLockOn()) keyMod |= KeyHandler.KEYMOD_NUM_LOCK;
+        // https://github.com/termux/termux-app/issues/731
+        if (!event.isFunctionPressed() && handleKeyCode(keyCode, keyMod)) {
+            if (TERMINAL_VIEW_KEY_LOGGING_ENABLED) mClient.logInfo(LOG_TAG, "handleKeyCode() took key event");
+            return true;
+        }
+
+        // Clear Ctrl since we handle that ourselves:
+        int bitsToClear = KeyEvent.META_CTRL_MASK;
+        if (rightAltDownFromEvent) {
+            // Let right Alt/Alt Gr be used to compose characters.
+        } else {
+            // Use left alt to send to terminal (e.g. Left Alt+B to jump back a word), so remove:
+            bitsToClear |= KeyEvent.META_ALT_ON | KeyEvent.META_ALT_LEFT_ON;
+        }
+        int effectiveMetaState = event.getMetaState() & ~bitsToClear;
+
+        if (shiftDown) effectiveMetaState |= KeyEvent.META_SHIFT_ON | KeyEvent.META_SHIFT_LEFT_ON;
+        if (mClient.readFnKey()) effectiveMetaState |= KeyEvent.META_FUNCTION_ON;
+
+        int result = event.getUnicodeChar(effectiveMetaState);
+        if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
+            mClient.logInfo(LOG_TAG, "KeyEvent#getUnicodeChar(" + effectiveMetaState + ") returned: " + result);
+        if (result == 0) {
+            return false;
+        }
+
+        int oldCombiningAccent = mCombiningAccent;
+        if ((result & KeyCharacterMap.COMBINING_ACCENT) != 0) {
+            // If entered combining accent previously, write it out:
+            if (mCombiningAccent != 0)
+                inputCodePoint(event.getDeviceId(), mCombiningAccent, controlDown, leftAltDown);
+            mCombiningAccent = result & KeyCharacterMap.COMBINING_ACCENT_MASK;
+        } else {
+            if (mCombiningAccent != 0) {
+                int combinedChar = KeyCharacterMap.getDeadChar(mCombiningAccent, result);
+                if (combinedChar > 0) result = combinedChar;
+                mCombiningAccent = 0;
+            }
+            inputCodePoint(event.getDeviceId(), result, controlDown, leftAltDown);
+        }
+
+        if (mCombiningAccent != oldCombiningAccent) invalidate();
+
+        return true;
+    }
+
+    public void inputCodePoint(int eventSource, int codePoint, boolean controlDownFromEvent, boolean leftAltDownFromEvent) {
+        if (TERMINAL_VIEW_KEY_LOGGING_ENABLED) {
+            mClient.logInfo(LOG_TAG, "inputCodePoint(eventSource=" + eventSource + ", codePoint=" + codePoint + ", controlDownFromEvent=" + controlDownFromEvent + ", leftAltDownFromEvent="
+                + leftAltDownFromEvent + ")");
+        }
+
+        if (mTermSession == null) return;
+
+        // Ensure cursor is shown when a key is pressed down like long hold on (arrow) keys
+        if (mEmulator != null)
+            mEmulator.setCursorBlinkState(true);
+
+        final boolean controlDown = controlDownFromEvent || mClient.readControlKey();
+        final boolean altDown = leftAltDownFromEvent || mClient.readAltKey();
+
+        if (mClient.onCodePoint(codePoint, controlDown, mTermSession)) return;
+
+        if (controlDown) {
+            if (codePoint >= 'a' && codePoint <= 'z') {
+                codePoint = codePoint - 'a' + 1;
+            } else if (codePoint >= 'A' && codePoint <= 'Z') {
+                codePoint = codePoint - 'A' + 1;
+            } else if (codePoint == ' ' || codePoint == '2') {
+                codePoint = 0;
+            } else if (codePoint == '[' || codePoint == '3') {
+                codePoint = 27; // ^[ (Esc)
+            } else if (codePoint == '\\' || codePoint == '4') {
+                codePoint = 28;
+            } else if (codePoint == ']' || codePoint == '5') {
+                codePoint = 29;
+            } else if (codePoint == '^' || codePoint == '6') {
+                codePoint = 30; // control-^
+            } else if (codePoint == '_' || codePoint == '7' || codePoint == '/') {
+                // "Ctrl-/ sends 0x1f which is equivalent of Ctrl-_ since the days of VT102"
+                // - http://apple.stackexchange.com/questions/24261/how-do-i-send-c-that-is-control-slash-to-the-terminal
+                codePoint = 31;
+            } else if (codePoint == '8') {
+                codePoint = 127; // DEL
+            }
+        }
+
+        if (codePoint > -1) {
+            // If not virtual or soft keyboard.
+            if (eventSource > KEY_EVENT_SOURCE_SOFT_KEYBOARD) {
+                // Work around bluetooth keyboards sending funny unicode characters instead
+                // of the more normal ones from ASCII that terminal programs expect - the
+                // desire to input the original characters should be low.
+                switch (codePoint) {
+                    case 0x02DC: // SMALL TILDE.
+                        codePoint = 0x007E; // TILDE (~).
+                        break;
+                    case 0x02CB: // MODIFIER LETTER GRAVE ACCENT.
+                        codePoint = 0x0060; // GRAVE ACCENT (`).
+                        break;
+                    case 0x02C6: // MODIFIER LETTER CIRCUMFLEX ACCENT.
+                        codePoint = 0x005E; // CIRCUMFLEX ACCENT (^).
+                        break;
+                }
+            }
+
+            // If left alt, send escape before the code point to make e.g. Alt+B and Alt+F work in readline:
+            mTermSession.writeCodePoint(altDown, codePoint);
+        }
+    }
+
+    /** Input the specified keyCode if applicable and return if the input was consumed. */
+    public boolean handleKeyCode(int keyCode, int keyMod) {
+        // Ensure cursor is shown when a key is pressed down like long hold on (arrow) keys
+        if (mEmulator != null)
+            mEmulator.setCursorBlinkState(true);
+
+        if (handleKeyCodeAction(keyCode, keyMod))
+            return true;
+
+        TerminalEmulator term = mTermSession.getEmulator();
+        String code = KeyHandler.getCode(keyCode, keyMod, term.isCursorKeysApplicationMode(), term.isKeypadApplicationMode());
+        if (code == null) return false;
+        mTermSession.write(code);
+        return true;
+    }
+
+    public boolean handleKeyCodeAction(int keyCode, int keyMod) {
+        boolean shiftDown = (keyMod & KeyHandler.KEYMOD_SHIFT) != 0;
+
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_PAGE_UP:
+            case KeyEvent.KEYCODE_PAGE_DOWN:
+                // shift+page_up and shift+page_down should scroll scrollback history instead of
+                // scrolling command history or changing pages
+                if (shiftDown) {
+                    long time = SystemClock.uptimeMillis();
+                    MotionEvent motionEvent = MotionEvent.obtain(time, time, MotionEvent.ACTION_DOWN, 0, 0, 0);
+                    doScroll(motionEvent, keyCode == KeyEvent.KEYCODE_PAGE_UP ? -mEmulator.mRows : mEmulator.mRows);
+                    motionEvent.recycle();
+                    return true;
+                }
+        }
+
+       return false;
+    }
+
+    /**
+     * Called when a key is released in the view.
+     *
+     * @param keyCode The keycode of the key which was released.
+     * @param event   A {@link KeyEvent} describing the event.
+     * @return Whether the event was handled.
+     */
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
+            mClient.logInfo(LOG_TAG, "onKeyUp(keyCode=" + keyCode + ", event=" + event + ")");
+
+        // Do not return for KEYCODE_BACK and send it to the client since user may be trying
+        // to exit the activity.
+        if (mEmulator == null && keyCode != KeyEvent.KEYCODE_BACK) return true;
+
+        if (mClient.onKeyUp(keyCode, event)) {
+            invalidate();
+            return true;
+        } else if (event.isSystem()) {
+            // Let system key events through.
+            return super.onKeyUp(keyCode, event);
+        }
+
+        return true;
+    }
+
+    /**
+     * This is called during layout when the size of this view has changed. If you were just added to the view
+     * hierarchy, you're called with the old values of 0.
+     */
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        updateSize();
+    }
+
+    /** Check if the terminal size in rows and columns should be updated. */
+    public void updateSize() {
+        int viewWidth = getWidth();
+        int viewHeight = getHeight();
+        if (viewWidth == 0 || viewHeight == 0 || mTermSession == null) return;
+
+        // Set to 80 and 24 if you want to enable vttest.
+        int newColumns = Math.max(4, (int) (viewWidth / mRenderer.mFontWidth));
+        int newRows = Math.max(4, (viewHeight - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
+
+        if (mEmulator == null || (newColumns != mEmulator.mColumns || newRows != mEmulator.mRows)) {
+            mTermSession.updateSize(newColumns, newRows, (int) mRenderer.getFontWidth(), mRenderer.getFontLineSpacing());
+            mEmulator = mTermSession.getEmulator();
+            mClient.onEmulatorSet();
+
+            // Update mTerminalCursorBlinkerRunnable inner class mEmulator on session change
+            if (mTerminalCursorBlinkerRunnable != null)
+                mTerminalCursorBlinkerRunnable.setEmulator(mEmulator);
+
+            mTopRow = 0;
+            scrollTo(0, 0);
+            invalidate();
+        }
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        if (mEmulator == null) {
+            canvas.drawColor(0XFF000000);
+        } else {
+            // render the terminal view and highlight any selected text
+            int[] sel = mDefaultSelectors;
+            if (mTextSelectionCursorController != null) {
+                mTextSelectionCursorController.getSelectors(sel);
+            }
+
+            mRenderer.render(mEmulator, canvas, mTopRow, sel[0], sel[1], sel[2], sel[3]);
+
+            // render the text selection handles
+            renderTextSelection();
+        }
+    }
+
+    public TerminalSession getCurrentSession() {
+        return mTermSession;
+    }
+
+    private CharSequence getText() {
+        return mEmulator.getScreen().getSelectedText(0, mTopRow, mEmulator.mColumns, mTopRow + mEmulator.mRows);
+    }
+
+    public int getCursorX(float x) {
+        return (int) (x / mRenderer.mFontWidth);
+    }
+
+    public int getCursorY(float y) {
+        return (int) (((y - 40) / mRenderer.mFontLineSpacing) + mTopRow);
+    }
+
+    public int getPointX(int cx) {
+        if (cx > mEmulator.mColumns) {
+            cx = mEmulator.mColumns;
+        }
+        return Math.round(cx * mRenderer.mFontWidth);
+    }
+
+    public int getPointY(int cy) {
+        return Math.round((cy - mTopRow) * mRenderer.mFontLineSpacing);
+    }
+
+    public int getTopRow() {
+        return mTopRow;
+    }
+
+    public void setTopRow(int mTopRow) {
+        this.mTopRow = mTopRow;
+    }
+
+
+
+    /**
+     * Define functions required for AutoFill API
+     */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public void autofill(AutofillValue value) {
+        if (value.isText()) {
+            mTermSession.write(value.getTextValue().toString());
+        }
+
+        resetAutoFill();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public int getAutofillType() {
+        return mAutoFillType;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public String[] getAutofillHints() {
+        return mAutoFillHints;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public AutofillValue getAutofillValue() {
+        return AutofillValue.forText("");
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public int getImportantForAutofill() {
+        return mAutoFillImportance;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private synchronized void resetAutoFill() {
+        // Restore none type so that AutoFill UI isn't shown anymore.
+        mAutoFillType = AUTOFILL_TYPE_NONE;
+        mAutoFillImportance = IMPORTANT_FOR_AUTOFILL_NO;
+        mAutoFillHints = new String[0];
+    }
+
+    public AutofillManager getAutoFillManagerService() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return null;
+
+        try {
+            Context context = getContext();
+            if (context == null) return null;
+            return context.getSystemService(AutofillManager.class);
+        } catch (Exception e) {
+            mClient.logStackTraceWithMessage(LOG_TAG, "Failed to get AutofillManager service", e);
+            return null;
+        }
+    }
+
+    public boolean isAutoFillEnabled() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false;
+
+        try {
+            AutofillManager autofillManager = getAutoFillManagerService();
+            return autofillManager != null && autofillManager.isEnabled();
+        } catch (Exception e) {
+            mClient.logStackTraceWithMessage(LOG_TAG, "Failed to check if Autofill is enabled", e);
+            return false;
+        }
+    }
+
+    public synchronized void requestAutoFillUsername() {
+        requestAutoFill(
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ? new String[]{View.AUTOFILL_HINT_USERNAME} :
+                null);
+    }
+
+    public synchronized void requestAutoFillPassword() {
+        requestAutoFill(
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ? new String[]{View.AUTOFILL_HINT_PASSWORD} :
+            null);
+    }
+
+    public synchronized void requestAutoFill(String[] autoFillHints) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        if (autoFillHints == null || autoFillHints.length < 1) return;
+
+        try {
+            AutofillManager autofillManager = getAutoFillManagerService();
+            if (autofillManager != null && autofillManager.isEnabled()) {
+                // Update type that will be returned by `getAutofillType()` so that AutoFill UI is shown.
+                mAutoFillType = AUTOFILL_TYPE_TEXT;
+                // Update importance that will be returned by `getImportantForAutofill()` so that
+                // AutoFill considers the view as important.
+                mAutoFillImportance = IMPORTANT_FOR_AUTOFILL_YES;
+                // Update hints that will be returned by `getAutofillHints()` for which to show AutoFill UI.
+                mAutoFillHints = autoFillHints;
+                autofillManager.requestAutofill(this);
+            }
+        } catch (Exception e) {
+            mClient.logStackTraceWithMessage(LOG_TAG, "Failed to request Autofill", e);
+        }
+    }
+
+    public synchronized void cancelRequestAutoFill() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        if (mAutoFillType == AUTOFILL_TYPE_NONE) return;
+
+        try {
+            AutofillManager autofillManager = getAutoFillManagerService();
+            if (autofillManager != null && autofillManager.isEnabled()) {
+                resetAutoFill();
+                autofillManager.cancel();
+            }
+        } catch (Exception e) {
+            mClient.logStackTraceWithMessage(LOG_TAG, "Failed to cancel Autofill request", e);
+        }
+    }
+
+
+
+
+
+    /**
+     * Set terminal cursor blinker rate. It must be between {@link #TERMINAL_CURSOR_BLINK_RATE_MIN}
+     * and {@link #TERMINAL_CURSOR_BLINK_RATE_MAX}, otherwise it will be disabled.
+     *
+     * The {@link #setTerminalCursorBlinkerState(boolean, boolean)} must be called after this
+     * for changes to take effect if not disabling.
+     *
+     * @param blinkRate The value to set.
+     * @return Returns {@code true} if setting blinker rate was successfully set, otherwise [@code false}.
+     */
+    public synchronized boolean setTerminalCursorBlinkerRate(int blinkRate) {
+        boolean result;
+
+        // If cursor blinking rate is not valid
+        if (blinkRate != 0 && (blinkRate < TERMINAL_CURSOR_BLINK_RATE_MIN || blinkRate > TERMINAL_CURSOR_BLINK_RATE_MAX)) {
+            mClient.logError(LOG_TAG, "The cursor blink rate must be in between " + TERMINAL_CURSOR_BLINK_RATE_MIN + "-" + TERMINAL_CURSOR_BLINK_RATE_MAX + ": " + blinkRate);
+            mTerminalCursorBlinkerRate = 0;
+            result = false;
+        } else {
+            mClient.logVerbose(LOG_TAG, "Setting cursor blinker rate to " + blinkRate);
+            mTerminalCursorBlinkerRate = blinkRate;
+            result = true;
+        }
+
+        if (mTerminalCursorBlinkerRate == 0) {
+            mClient.logVerbose(LOG_TAG, "Cursor blinker disabled");
+            stopTerminalCursorBlinker();
+        }
+
+        return result;
+    }
+
+    /**
+     * Sets whether cursor blinker should be started or stopped. Cursor blinker will only be
+     * started if {@link #mTerminalCursorBlinkerRate} does not equal 0 and is between
+     * {@link #TERMINAL_CURSOR_BLINK_RATE_MIN} and {@link #TERMINAL_CURSOR_BLINK_RATE_MAX}.
+     *
+     * This should be called when the view holding this activity is resumed or stopped so that
+     * cursor blinker does not run when activity is not visible. If you call this on onResume()
+     * to start cursor blinking, then ensure that {@link #mEmulator} is set, otherwise wait for the
+     * {@link TerminalViewClient#onEmulatorSet()} event after calling {@link #attachSession(TerminalSession)}
+     * for the first session added in the activity since blinking will not start if {@link #mEmulator}
+     * is not set, like if activity is started again after exiting it with double back press. Do not
+     * call this directly after {@link #attachSession(TerminalSession)} since {@link #updateSize()}
+     * may return without setting {@link #mEmulator} since width/height may be 0. Its called again in
+     * {@link #onSizeChanged(int, int, int, int)}. Calling on onResume() if emulator is already set
+     * is necessary, since onEmulatorSet() may not be called after activity is started after device
+     * display timeout with double tap and not power button.
+     *
+     * It should also be called on the
+     * {@link com.termux.terminal.TerminalSessionClient#onTerminalCursorStateChange(boolean)}
+     * callback when cursor is enabled or disabled so that blinker is disabled if cursor is not
+     * to be shown. It should also be checked if activity is visible if blinker is to be started
+     * before calling this.
+     *
+     * It should also be called after terminal is reset with {@link TerminalSession#reset()} in case
+     * cursor blinker was disabled before reset due to call to
+     * {@link com.termux.terminal.TerminalSessionClient#onTerminalCursorStateChange(boolean)}.
+     *
+     * How cursor blinker starting works is by registering a {@link Runnable} with the looper of
+     * the main thread of the app which when run, toggles the cursor blinking state and re-registers
+     * itself to be called with the delay set by {@link #mTerminalCursorBlinkerRate}. When cursor
+     * blinking needs to be disabled, we just cancel any callbacks registered. We don't run our own
+     * "thread" and let the thread for the main looper do the work for us, whose usage is also
+     * required to update the UI, since it also handles other calls to update the UI as well based
+     * on a queue.
+     *
+     * Note that when moving cursor in text editors like nano, the cursor state is quickly
+     * toggled `-> off -> on`, which would call this very quickly sequentially. So that if cursor
+     * is moved 2 or more times quickly, like long hold on arrow keys, it would trigger
+     * `-> off -> on -> off -> on -> ...`, and the "on" callback at index 2 is automatically
+     * cancelled by next "off" callback at index 3 before getting a chance to be run. For this case
+     * we log only if {@link #TERMINAL_VIEW_KEY_LOGGING_ENABLED} is enabled, otherwise would clutter
+     * the log. We don't start the blinking with a delay to immediately show cursor in case it was
+     * previously not visible.
+     *
+     * @param start If cursor blinker should be started or stopped.
+     * @param startOnlyIfCursorEnabled If set to {@code true}, then it will also be checked if the
+     *                                 cursor is even enabled by {@link TerminalEmulator} before
+     *                                 starting the cursor blinker.
+     */
+    public synchronized void setTerminalCursorBlinkerState(boolean start, boolean startOnlyIfCursorEnabled) {
+        // Stop any existing cursor blinker callbacks
+        stopTerminalCursorBlinker();
+
+        if (mEmulator == null) return;
+
+        mEmulator.setCursorBlinkingEnabled(false);
+
+        if (start) {
+            // If cursor blinker is not enabled or is not valid
+            if (mTerminalCursorBlinkerRate < TERMINAL_CURSOR_BLINK_RATE_MIN || mTerminalCursorBlinkerRate > TERMINAL_CURSOR_BLINK_RATE_MAX)
+                return;
+            // If cursor blinder is to be started only if cursor is enabled
+            else if (startOnlyIfCursorEnabled && ! mEmulator.isCursorEnabled()) {
+                if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
+                    mClient.logVerbose(LOG_TAG, "Ignoring call to start cursor blinker since cursor is not enabled");
+                return;
+            }
+
+            // Start cursor blinker runnable
+            if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
+                mClient.logVerbose(LOG_TAG, "Starting cursor blinker with the blink rate " + mTerminalCursorBlinkerRate);
+            if (mTerminalCursorBlinkerHandler == null)
+                mTerminalCursorBlinkerHandler = new Handler(Looper.getMainLooper());
+            mTerminalCursorBlinkerRunnable = new TerminalCursorBlinkerRunnable(mEmulator, mTerminalCursorBlinkerRate);
+            mEmulator.setCursorBlinkingEnabled(true);
+            mTerminalCursorBlinkerRunnable.run();
+        }
+    }
+
+    /**
+     * Cancel the terminal cursor blinker callbacks
+     */
+    private void stopTerminalCursorBlinker() {
+        if (mTerminalCursorBlinkerHandler != null && mTerminalCursorBlinkerRunnable != null) {
+            if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
+                mClient.logVerbose(LOG_TAG, "Stopping cursor blinker");
+            mTerminalCursorBlinkerHandler.removeCallbacks(mTerminalCursorBlinkerRunnable);
+        }
+    }
+
+    private class TerminalCursorBlinkerRunnable implements Runnable {
+
+        private TerminalEmulator mEmulator;
+        private final int mBlinkRate;
+
+        // Initialize with false so that initial blink state is visible after toggling
+        boolean mCursorVisible = false;
+
+        public TerminalCursorBlinkerRunnable(TerminalEmulator emulator, int blinkRate) {
+            mEmulator = emulator;
+            mBlinkRate = blinkRate;
+        }
+
+        public void setEmulator(TerminalEmulator emulator) {
+            mEmulator = emulator;
+        }
+
+        public void run() {
+            try {
+                if (mEmulator != null) {
+                    // Toggle the blink state and then invalidate() the view so
+                    // that onDraw() is called, which then calls TerminalRenderer.render()
+                    // which checks with TerminalEmulator.shouldCursorBeVisible() to decide whether
+                    // to draw the cursor or not
+                    mCursorVisible = !mCursorVisible;
+                    //mClient.logVerbose(LOG_TAG, "Toggling cursor blink state to " + mCursorVisible);
+                    mEmulator.setCursorBlinkState(mCursorVisible);
+                    invalidate();
+                }
+            } finally {
+                // Recall the Runnable after mBlinkRate milliseconds to toggle the blink state
+                mTerminalCursorBlinkerHandler.postDelayed(this, mBlinkRate);
+            }
+        }
+    }
+
+
+
+    /**
+     * Define functions required for text selection and its handles.
+     */
+    TextSelectionCursorController getTextSelectionCursorController() {
+        if (mTextSelectionCursorController == null) {
+            mTextSelectionCursorController = new TextSelectionCursorController(this);
+
+            final ViewTreeObserver observer = getViewTreeObserver();
+            if (observer != null) {
+                observer.addOnTouchModeChangeListener(mTextSelectionCursorController);
+            }
+        }
+
+        return mTextSelectionCursorController;
+    }
+
+    private void showTextSelectionCursors(MotionEvent event) {
+        getTextSelectionCursorController().show(event);
+    }
+
+    private boolean hideTextSelectionCursors() {
+        return getTextSelectionCursorController().hide();
+    }
+
+    private void renderTextSelection() {
+        if (mTextSelectionCursorController != null)
+            mTextSelectionCursorController.render();
+    }
+
+    public boolean isSelectingText() {
+        if (mTextSelectionCursorController != null) {
+            return mTextSelectionCursorController.isActive();
+        } else {
+            return false;
+        }
+    }
+
+    /** Get the currently selected text if selecting. */
+    public String getSelectedText() {
+        if (isSelectingText() && mTextSelectionCursorController != null)
+            return mTextSelectionCursorController.getSelectedText();
+        else
+            return null;
+    }
+
+    /** Get the selected text stored before "MORE" button was pressed on the context menu. */
+    @Nullable
+    public String getStoredSelectedText() {
+        return mTextSelectionCursorController != null ? mTextSelectionCursorController.getStoredSelectedText() : null;
+    }
+
+    /** Unset the selected text stored before "MORE" button was pressed on the context menu. */
+    public void unsetStoredSelectedText() {
+        if (mTextSelectionCursorController != null) mTextSelectionCursorController.unsetStoredSelectedText();
+    }
+
+    private ActionMode getTextSelectionActionMode() {
+        if (mTextSelectionCursorController != null) {
+            return mTextSelectionCursorController.getActionMode();
+        } else {
+            return null;
+        }
+    }
+
+    public void startTextSelectionMode(MotionEvent event) {
+        if (!requestFocus()) {
+            return;
+        }
+
+        showTextSelectionCursors(event);
+        mClient.copyModeChanged(isSelectingText());
+
+        invalidate();
+    }
+
+    public void stopTextSelectionMode() {
+        if (hideTextSelectionCursors()) {
+            mClient.copyModeChanged(isSelectingText());
+            invalidate();
+        }
+    }
+
+    private void decrementYTextSelectionCursors(int decrement) {
+        if (mTextSelectionCursorController != null) {
+            mTextSelectionCursorController.decrementYTextSelectionCursors(decrement);
+        }
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        if (mTextSelectionCursorController != null) {
+            getViewTreeObserver().addOnTouchModeChangeListener(mTextSelectionCursorController);
+        }
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+
+        if (mTextSelectionCursorController != null) {
+            // Might solve the following exception
+            // android.view.WindowLeaked: Activity com.termux.app.TermuxActivity has leaked window android.widget.PopupWindow
+            stopTextSelectionMode();
+
+            getViewTreeObserver().removeOnTouchModeChangeListener(mTextSelectionCursorController);
+            mTextSelectionCursorController.onDetached();
+        }
+    }
+
+
+
+    /**
+     * Define functions required for long hold toolbar.
+     */
+    private final Runnable mShowFloatingToolbar = new Runnable() {
+        @RequiresApi(api = Build.VERSION_CODES.M)
+        @Override
+        public void run() {
+            if (getTextSelectionActionMode() != null) {
+                getTextSelectionActionMode().hide(0);  // hide off.
+            }
+        }
+    };
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private void showFloatingToolbar() {
+        if (getTextSelectionActionMode() != null) {
+            int delay = ViewConfiguration.getDoubleTapTimeout();
+            postDelayed(mShowFloatingToolbar, delay);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    void hideFloatingToolbar() {
+        if (getTextSelectionActionMode() != null) {
+            removeCallbacks(mShowFloatingToolbar);
+            getTextSelectionActionMode().hide(-1);
+        }
+    }
+
+    public void updateFloatingToolbarVisibility(MotionEvent event) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && getTextSelectionActionMode() != null) {
+            switch (event.getActionMasked()) {
+                case MotionEvent.ACTION_MOVE:
+                    hideFloatingToolbar();
+                    break;
+                case MotionEvent.ACTION_UP:  // fall through
+                case MotionEvent.ACTION_CANCEL:
+                    showFloatingToolbar();
+            }
+        }
+    }
+
+}

--- a/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
@@ -1,0 +1,83 @@
+package com.termux.view;
+
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
+import android.view.View;
+
+import com.termux.terminal.TerminalSession;
+
+/**
+ * The interface for communication between {@link TerminalView} and its client. It allows for getting
+ * various  configuration options from the client and for sending back data to the client like logs,
+ * key events, both hardware and IME (which makes it different from that available with
+ * {@link View#setOnKeyListener(View.OnKeyListener)}, etc. It must be set for the
+ * {@link TerminalView} through {@link TerminalView#setTerminalViewClient(TerminalViewClient)}.
+ */
+public interface TerminalViewClient {
+
+    /**
+     * Callback function on scale events according to {@link ScaleGestureDetector#getScaleFactor()}.
+     */
+    float onScale(float scale);
+
+
+
+    /**
+     * On a single tap on the terminal if terminal mouse reporting not enabled.
+     */
+    void onSingleTapUp(MotionEvent e);
+
+    boolean shouldBackButtonBeMappedToEscape();
+
+    boolean shouldEnforceCharBasedInput();
+
+    boolean shouldUseCtrlSpaceWorkaround();
+
+    boolean isTerminalViewSelected();
+
+
+
+    void copyModeChanged(boolean copyMode);
+
+
+
+    boolean onKeyDown(int keyCode, KeyEvent e, TerminalSession session);
+
+    boolean onKeyUp(int keyCode, KeyEvent e);
+
+    boolean onLongPress(MotionEvent event);
+
+
+
+    boolean readControlKey();
+
+    boolean readAltKey();
+
+    boolean readShiftKey();
+
+    boolean readFnKey();
+
+
+
+    boolean onCodePoint(int codePoint, boolean ctrlDown, TerminalSession session);
+
+
+    void onEmulatorSet();
+
+
+    void logError(String tag, String message);
+
+    void logWarn(String tag, String message);
+
+    void logInfo(String tag, String message);
+
+    void logDebug(String tag, String message);
+
+    void logVerbose(String tag, String message);
+
+    void logStackTraceWithMessage(String tag, String message, Exception e);
+
+    void logStackTrace(String tag, Exception e);
+
+}

--- a/terminal-view/src/main/java/com/termux/view/support/PopupWindowCompatGingerbread.java
+++ b/terminal-view/src/main/java/com/termux/view/support/PopupWindowCompatGingerbread.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package com.termux.view.support;
+
+import android.util.Log;
+import android.widget.PopupWindow;
+
+import java.lang.reflect.Method;
+
+/**
+ * Implementation of PopupWindow compatibility that can call Gingerbread APIs.
+ * https://chromium.googlesource.com/android_tools/+/HEAD/sdk/extras/android/support/v4/src/gingerbread/android/support/v4/widget/PopupWindowCompatGingerbread.java
+ */
+public class PopupWindowCompatGingerbread {
+
+    private static Method sSetWindowLayoutTypeMethod;
+    private static boolean sSetWindowLayoutTypeMethodAttempted;
+    private static Method sGetWindowLayoutTypeMethod;
+    private static boolean sGetWindowLayoutTypeMethodAttempted;
+
+    public static void setWindowLayoutType(PopupWindow popupWindow, int layoutType) {
+        if (!sSetWindowLayoutTypeMethodAttempted) {
+            try {
+                sSetWindowLayoutTypeMethod = PopupWindow.class.getDeclaredMethod(
+                    "setWindowLayoutType", int.class);
+                sSetWindowLayoutTypeMethod.setAccessible(true);
+            } catch (Exception e) {
+                // Reflection method fetch failed. Oh well.
+            }
+            sSetWindowLayoutTypeMethodAttempted = true;
+        }
+        if (sSetWindowLayoutTypeMethod != null) {
+            try {
+                sSetWindowLayoutTypeMethod.invoke(popupWindow, layoutType);
+            } catch (Exception e) {
+                // Reflection call failed. Oh well.
+            }
+        }
+    }
+
+    public static int getWindowLayoutType(PopupWindow popupWindow) {
+        if (!sGetWindowLayoutTypeMethodAttempted) {
+            try {
+                sGetWindowLayoutTypeMethod = PopupWindow.class.getDeclaredMethod(
+                    "getWindowLayoutType");
+                sGetWindowLayoutTypeMethod.setAccessible(true);
+            } catch (Exception e) {
+                // Reflection method fetch failed. Oh well.
+            }
+            sGetWindowLayoutTypeMethodAttempted = true;
+        }
+        if (sGetWindowLayoutTypeMethod != null) {
+            try {
+                return (Integer) sGetWindowLayoutTypeMethod.invoke(popupWindow);
+            } catch (Exception e) {
+                // Reflection call failed. Oh well.
+            }
+        }
+        return 0;
+    }
+
+}

--- a/terminal-view/src/main/java/com/termux/view/textselection/CursorController.java
+++ b/terminal-view/src/main/java/com/termux/view/textselection/CursorController.java
@@ -1,0 +1,55 @@
+package com.termux.view.textselection;
+
+import android.view.MotionEvent;
+import android.view.ViewTreeObserver;
+
+import com.termux.view.TerminalView;
+
+/**
+ * A CursorController instance can be used to control cursors in the text.
+ * It is not used outside of {@link TerminalView}.
+ */
+public interface CursorController extends ViewTreeObserver.OnTouchModeChangeListener {
+    /**
+     * Show the cursors on screen. Will be drawn by {@link #render()} by a call during onDraw.
+     * See also {@link #hide()}.
+     */
+    void show(MotionEvent event);
+
+    /**
+     * Hide the cursors from screen.
+     * See also {@link #show(MotionEvent event)}.
+     */
+    boolean hide();
+
+    /**
+     * Render the cursors.
+     */
+    void render();
+
+    /**
+     * Update the cursor positions.
+     */
+    void updatePosition(TextSelectionHandleView handle, int x, int y);
+
+    /**
+     * This method is called by {@link #onTouchEvent(MotionEvent)} and gives the cursors
+     * a chance to become active and/or visible.
+     *
+     * @param event The touch event
+     */
+    boolean onTouchEvent(MotionEvent event);
+
+    /**
+     * Called when the view is detached from window. Perform house keeping task, such as
+     * stopping Runnable thread that would otherwise keep a reference on the context, thus
+     * preventing the activity to be recycled.
+     */
+    void onDetached();
+
+    /**
+     * @return true if the cursors are currently active.
+     */
+    boolean isActive();
+
+}

--- a/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
+++ b/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
@@ -1,0 +1,407 @@
+package com.termux.view.textselection;
+
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.graphics.Rect;
+import android.os.Build;
+import android.text.TextUtils;
+import android.view.ActionMode;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+import com.termux.terminal.TerminalBuffer;
+import com.termux.terminal.WcWidth;
+import com.termux.view.R;
+import com.termux.view.TerminalView;
+
+public class TextSelectionCursorController implements CursorController {
+
+    private final TerminalView terminalView;
+    private final TextSelectionHandleView mStartHandle, mEndHandle;
+    private String mStoredSelectedText;
+    private boolean mIsSelectingText = false;
+    private long mShowStartTime = System.currentTimeMillis();
+
+    private final int mHandleHeight;
+    private int mSelX1 = -1, mSelX2 = -1, mSelY1 = -1, mSelY2 = -1;
+
+    private ActionMode mActionMode;
+    public final int ACTION_COPY = 1;
+    public final int ACTION_PASTE = 2;
+    public final int ACTION_MORE = 3;
+
+    public TextSelectionCursorController(TerminalView terminalView) {
+        this.terminalView = terminalView;
+        mStartHandle = new TextSelectionHandleView(terminalView, this, TextSelectionHandleView.LEFT);
+        mEndHandle = new TextSelectionHandleView(terminalView, this, TextSelectionHandleView.RIGHT);
+
+        mHandleHeight = Math.max(mStartHandle.getHandleHeight(), mEndHandle.getHandleHeight());
+    }
+
+    @Override
+    public void show(MotionEvent event) {
+        setInitialTextSelectionPosition(event);
+        mStartHandle.positionAtCursor(mSelX1, mSelY1, true);
+        mEndHandle.positionAtCursor(mSelX2 + 1, mSelY2, true);
+
+        setActionModeCallBacks();
+        mShowStartTime = System.currentTimeMillis();
+        mIsSelectingText = true;
+    }
+
+    @Override
+    public boolean hide() {
+        if (!isActive()) return false;
+
+        // prevent hide calls right after a show call, like long pressing the down key
+        // 300ms seems long enough that it wouldn't cause hide problems if action button
+        // is quickly clicked after the show, otherwise decrease it
+        if (System.currentTimeMillis() - mShowStartTime < 300) {
+            return false;
+        }
+
+        mStartHandle.hide();
+        mEndHandle.hide();
+
+        if (mActionMode != null) {
+            // This will hide the TextSelectionCursorController
+            mActionMode.finish();
+        }
+
+        mSelX1 = mSelY1 = mSelX2 = mSelY2 = -1;
+        mIsSelectingText = false;
+
+        return true;
+    }
+
+    @Override
+    public void render() {
+        if (!isActive()) return;
+
+        mStartHandle.positionAtCursor(mSelX1, mSelY1, false);
+        mEndHandle.positionAtCursor(mSelX2 + 1, mSelY2, false);
+
+        if (mActionMode != null) {
+            mActionMode.invalidate();
+        }
+    }
+
+    public void setInitialTextSelectionPosition(MotionEvent event) {
+        int[] columnAndRow = terminalView.getColumnAndRow(event, true);
+        mSelX1 = mSelX2 = columnAndRow[0];
+        mSelY1 = mSelY2 = columnAndRow[1];
+
+        TerminalBuffer screen = terminalView.mEmulator.getScreen();
+        if (!" ".equals(screen.getSelectedText(mSelX1, mSelY1, mSelX1, mSelY1))) {
+            // Selecting something other than whitespace. Expand to word.
+            while (mSelX1 > 0 && !"".equals(screen.getSelectedText(mSelX1 - 1, mSelY1, mSelX1 - 1, mSelY1))) {
+                mSelX1--;
+            }
+            while (mSelX2 < terminalView.mEmulator.mColumns - 1 && !"".equals(screen.getSelectedText(mSelX2 + 1, mSelY1, mSelX2 + 1, mSelY1))) {
+                mSelX2++;
+            }
+        }
+    }
+    
+    public void setActionModeCallBacks() {
+        final ActionMode.Callback callback = new ActionMode.Callback() {
+            @Override
+            public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+                int show = MenuItem.SHOW_AS_ACTION_IF_ROOM | MenuItem.SHOW_AS_ACTION_WITH_TEXT;
+
+                ClipboardManager clipboard = (ClipboardManager) terminalView.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+                menu.add(Menu.NONE, ACTION_COPY, Menu.NONE, R.string.copy_text).setShowAsAction(show);
+                menu.add(Menu.NONE, ACTION_PASTE, Menu.NONE, R.string.paste_text).setEnabled(clipboard != null && clipboard.hasPrimaryClip()).setShowAsAction(show);
+                menu.add(Menu.NONE, ACTION_MORE, Menu.NONE, R.string.text_selection_more);
+                return true;
+            }
+
+            @Override
+            public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+                return false;
+            }
+
+            @Override
+            public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+                if (!isActive()) {
+                    // Fix issue where the dialog is pressed while being dismissed.
+                    return true;
+                }
+
+                switch (item.getItemId()) {
+                    case ACTION_COPY:
+                        String selectedText = getSelectedText();
+                        terminalView.mTermSession.onCopyTextToClipboard(selectedText);
+                        terminalView.stopTextSelectionMode();
+                        break;
+                    case ACTION_PASTE:
+                        terminalView.stopTextSelectionMode();
+                        terminalView.mTermSession.onPasteTextFromClipboard();
+                        break;
+                    case ACTION_MORE:
+                        // We first store the selected text in case TerminalViewClient needs the
+                        // selected text before MORE button was pressed since we are going to
+                        // stop selection mode
+                        mStoredSelectedText = getSelectedText();
+                        // The text selection needs to be stopped before showing context menu,
+                        // otherwise handles will show above popup
+                        terminalView.stopTextSelectionMode();
+                        terminalView.showContextMenu();
+                        break;
+                }
+
+                return true;
+            }
+
+            @Override
+            public void onDestroyActionMode(ActionMode mode) {
+            }
+
+        };
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            mActionMode = terminalView.startActionMode(callback);
+            return;
+        }
+
+        //noinspection NewApi
+        mActionMode = terminalView.startActionMode(new ActionMode.Callback2() {
+            @Override
+            public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+                return callback.onCreateActionMode(mode, menu);
+            }
+
+            @Override
+            public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+                return false;
+            }
+
+            @Override
+            public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+                return callback.onActionItemClicked(mode, item);
+            }
+
+            @Override
+            public void onDestroyActionMode(ActionMode mode) {
+                // Ignore.
+            }
+
+            @Override
+            public void onGetContentRect(ActionMode mode, View view, Rect outRect) {
+                int x1 = Math.round(mSelX1 * terminalView.mRenderer.getFontWidth());
+                int x2 = Math.round(mSelX2 * terminalView.mRenderer.getFontWidth());
+                int y1 = Math.round((mSelY1 - 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
+                int y2 = Math.round((mSelY2 + 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
+
+                if (x1 > x2) {
+                    int tmp = x1;
+                    x1 = x2;
+                    x2 = tmp;
+                }
+
+                int terminalBottom = terminalView.getBottom();
+                int top = y1 + mHandleHeight;
+                int bottom = y2 + mHandleHeight;
+                if (top > terminalBottom) top = terminalBottom;
+                if (bottom > terminalBottom) bottom = terminalBottom;
+
+                outRect.set(x1, top, x2, bottom);
+            }
+        }, ActionMode.TYPE_FLOATING);
+    }
+
+    @Override
+    public void updatePosition(TextSelectionHandleView handle, int x, int y) {
+        TerminalBuffer screen = terminalView.mEmulator.getScreen();
+        final int scrollRows = screen.getActiveRows() - terminalView.mEmulator.mRows;
+        if (handle == mStartHandle) {
+            mSelX1 = terminalView.getCursorX(x);
+            mSelY1 = terminalView.getCursorY(y);
+            if (mSelX1 < 0) {
+                mSelX1 = 0;
+            }
+
+            if (mSelY1 < -scrollRows) {
+                mSelY1 = -scrollRows;
+
+            } else if (mSelY1 > terminalView.mEmulator.mRows - 1) {
+                mSelY1 = terminalView.mEmulator.mRows - 1;
+
+            }
+
+            if (mSelY1 > mSelY2) {
+                mSelY1 = mSelY2;
+            }
+            if (mSelY1 == mSelY2 && mSelX1 > mSelX2) {
+                mSelX1 = mSelX2;
+            }
+
+            if (!terminalView.mEmulator.isAlternateBufferActive()) {
+                int topRow = terminalView.getTopRow();
+
+                if (mSelY1 <= topRow) {
+                    topRow--;
+                    if (topRow < -scrollRows) {
+                        topRow = -scrollRows;
+                    }
+                } else if (mSelY1 >= topRow + terminalView.mEmulator.mRows) {
+                    topRow++;
+                    if (topRow > 0) {
+                        topRow = 0;
+                    }
+                }
+
+                terminalView.setTopRow(topRow);
+            }
+
+            mSelX1 = getValidCurX(screen, mSelY1, mSelX1);
+
+        } else {
+            mSelX2 = terminalView.getCursorX(x);
+            mSelY2 = terminalView.getCursorY(y);
+            if (mSelX2 < 0) {
+                mSelX2 = 0;
+            }
+
+            if (mSelY2 < -scrollRows) {
+                mSelY2 = -scrollRows;
+            } else if (mSelY2 > terminalView.mEmulator.mRows - 1) {
+                mSelY2 = terminalView.mEmulator.mRows - 1;
+            }
+
+            if (mSelY1 > mSelY2) {
+                mSelY2 = mSelY1;
+            }
+            if (mSelY1 == mSelY2 && mSelX1 > mSelX2) {
+                mSelX2 = mSelX1;
+            }
+
+            if (!terminalView.mEmulator.isAlternateBufferActive()) {
+                int topRow = terminalView.getTopRow();
+
+                if (mSelY2 <= topRow) {
+                    topRow--;
+                    if (topRow < -scrollRows) {
+                        topRow = -scrollRows;
+                    }
+                } else if (mSelY2 >= topRow + terminalView.mEmulator.mRows) {
+                    topRow++;
+                    if (topRow > 0) {
+                        topRow = 0;
+                    }
+                }
+
+                terminalView.setTopRow(topRow);
+            }
+
+            mSelX2 = getValidCurX(screen, mSelY2, mSelX2);
+        }
+
+        terminalView.invalidate();
+    }
+
+    private int getValidCurX(TerminalBuffer screen, int cy, int cx) {
+        String line = screen.getSelectedText(0, cy, cx, cy);
+        if (!TextUtils.isEmpty(line)) {
+            int col = 0;
+            for (int i = 0, len = line.length(); i < len; i++) {
+                char ch1 = line.charAt(i);
+                if (ch1 == 0) {
+                    break;
+                }
+
+                int wc;
+                if (Character.isHighSurrogate(ch1) && i + 1 < len) {
+                    char ch2 = line.charAt(++i);
+                    wc = WcWidth.width(Character.toCodePoint(ch1, ch2));
+                } else {
+                    wc = WcWidth.width(ch1);
+                }
+
+                final int cend = col + wc;
+                if (cx > col && cx < cend) {
+                    return cend;
+                }
+                if (cend == col) {
+                    return col;
+                }
+                col = cend;
+            }
+        }
+        return cx;
+    }
+
+    public void decrementYTextSelectionCursors(int decrement) {
+        mSelY1 -= decrement;
+        mSelY2 -= decrement;
+    }
+
+    public boolean onTouchEvent(MotionEvent event) {
+        return false;
+    }
+
+    public void onTouchModeChanged(boolean isInTouchMode) {
+        if (!isInTouchMode) {
+            terminalView.stopTextSelectionMode();
+        }
+    }
+
+    @Override
+    public void onDetached() {
+    }
+
+    @Override
+    public boolean isActive() {
+        return mIsSelectingText;
+    }
+
+    public void getSelectors(int[] sel) {
+        if (sel == null || sel.length != 4) {
+            return;
+        }
+
+        sel[0] = mSelY1;
+        sel[1] = mSelY2;
+        sel[2] = mSelX1;
+        sel[3] = mSelX2;
+    }
+
+    /** Get the currently selected text. */
+    public String getSelectedText() {
+        return terminalView.mEmulator.getSelectedText(mSelX1, mSelY1, mSelX2, mSelY2);
+    }
+
+    /** Get the selected text stored before "MORE" button was pressed on the context menu. */
+    @Nullable
+    public String getStoredSelectedText() {
+        return mStoredSelectedText;
+    }
+
+    /** Unset the selected text stored before "MORE" button was pressed on the context menu. */
+    public void unsetStoredSelectedText() {
+        mStoredSelectedText = null;
+    }
+
+    public ActionMode getActionMode() {
+        return mActionMode;
+    }
+
+    /**
+     * @return true if this controller is currently used to move the start selection.
+     */
+    public boolean isSelectionStartDragged() {
+        return mStartHandle.isDragging();
+    }
+
+    /**
+     * @return true if this controller is currently used to move the end selection.
+     */
+    public boolean isSelectionEndDragged() {
+        return mEndHandle.isDragging();
+    }
+
+}

--- a/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionHandleView.java
+++ b/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionHandleView.java
@@ -1,0 +1,352 @@
+package com.termux.view.textselection;
+
+import android.annotation.SuppressLint;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.SystemClock;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.view.WindowManager;
+import android.widget.PopupWindow;
+
+import com.termux.view.R;
+import com.termux.view.TerminalView;
+import com.termux.view.support.PopupWindowCompatGingerbread;
+
+@SuppressLint("ViewConstructor")
+public class TextSelectionHandleView extends View {
+    private final TerminalView terminalView;
+    private PopupWindow mHandle;
+    private final CursorController mCursorController;
+
+    private final Drawable mHandleLeftDrawable;
+    private final Drawable mHandleRightDrawable;
+    private Drawable mHandleDrawable;
+
+    private boolean mIsDragging;
+
+    final int[] mTempCoords = new int[2];
+    Rect mTempRect;
+
+    private int mPointX;
+    private int mPointY;
+    private float mTouchToWindowOffsetX;
+    private float mTouchToWindowOffsetY;
+    private float mHotspotX;
+    private float mHotspotY;
+    private float mTouchOffsetY;
+    private int mLastParentX;
+    private int mLastParentY;
+
+    private int mHandleHeight;
+    private int mHandleWidth;
+
+    private final int mInitialOrientation;
+    private int mOrientation;
+
+    public static final int LEFT = 0;
+    public static final int RIGHT = 2;
+
+    private long mLastTime;
+
+    public TextSelectionHandleView(TerminalView terminalView, CursorController cursorController, int initialOrientation) {
+        super(terminalView.getContext());
+        this.terminalView = terminalView;
+        mCursorController = cursorController;
+        mInitialOrientation = initialOrientation;
+
+        mHandleLeftDrawable = getContext().getDrawable(R.drawable.text_select_handle_left_material);
+        mHandleRightDrawable = getContext().getDrawable(R.drawable.text_select_handle_right_material);
+
+        setOrientation(mInitialOrientation);
+    }
+
+    private void initHandle() {
+        mHandle = new PopupWindow(terminalView.getContext(), null,
+            android.R.attr.textSelectHandleWindowStyle);
+        mHandle.setSplitTouchEnabled(true);
+        mHandle.setClippingEnabled(false);
+        mHandle.setWidth(ViewGroup.LayoutParams.WRAP_CONTENT);
+        mHandle.setHeight(ViewGroup.LayoutParams.WRAP_CONTENT);
+        mHandle.setBackgroundDrawable(null);
+        mHandle.setAnimationStyle(0);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            mHandle.setWindowLayoutType(WindowManager.LayoutParams.TYPE_APPLICATION_SUB_PANEL);
+            mHandle.setEnterTransition(null);
+            mHandle.setExitTransition(null);
+        } else {
+            PopupWindowCompatGingerbread.setWindowLayoutType(mHandle, WindowManager.LayoutParams.TYPE_APPLICATION_SUB_PANEL);
+        }
+        mHandle.setContentView(this);
+    }
+
+    public void setOrientation(int orientation) {
+        mOrientation = orientation;
+        int handleWidth = 0;
+        switch (orientation) {
+            case LEFT: {
+                mHandleDrawable = mHandleLeftDrawable;
+                handleWidth = mHandleDrawable.getIntrinsicWidth();
+                mHotspotX = (handleWidth * 3) / (float) 4;
+                break;
+            }
+
+            case RIGHT: {
+                mHandleDrawable = mHandleRightDrawable;
+                handleWidth = mHandleDrawable.getIntrinsicWidth();
+                mHotspotX = handleWidth / (float) 4;
+                break;
+            }
+        }
+
+        mHandleHeight = mHandleDrawable.getIntrinsicHeight();
+
+        mHandleWidth = handleWidth;
+        mTouchOffsetY = -mHandleHeight * 0.3f;
+        mHotspotY = 0;
+        invalidate();
+    }
+
+    public void show() {
+        if (!isPositionVisible()) {
+            hide();
+            return;
+        }
+
+        // We remove handle from its parent first otherwise the following exception may be thrown
+        // java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
+        removeFromParent();
+
+        initHandle(); // init the handle
+        invalidate(); // invalidate to make sure onDraw is called
+
+        final int[] coords = mTempCoords;
+        terminalView.getLocationInWindow(coords);
+        coords[0] += mPointX;
+        coords[1] += mPointY;
+
+        if (mHandle != null)
+            mHandle.showAtLocation(terminalView, 0, coords[0], coords[1]);
+    }
+
+    public void hide() {
+        mIsDragging = false;
+
+        if (mHandle != null) {
+            mHandle.dismiss();
+
+            // We remove handle from its parent, otherwise it may still be shown in some cases even after the dismiss call
+            removeFromParent();
+            mHandle = null;  // garbage collect the handle
+        }
+        invalidate();
+    }
+
+    public void removeFromParent() {
+        if (!isParentNull()) {
+            ((ViewGroup)this.getParent()).removeView(this);
+        }
+    }
+
+    public void positionAtCursor(final int cx, final int cy, boolean forceOrientationCheck) {
+        int x = terminalView.getPointX(cx);
+        int y = terminalView.getPointY(cy + 1);
+        moveTo(x, y, forceOrientationCheck);
+    }
+
+    private void moveTo(int x, int y, boolean forceOrientationCheck) {
+        float oldHotspotX = mHotspotX;
+        checkChangedOrientation(x, forceOrientationCheck);
+        mPointX = (int) (x - (isShowing() ? oldHotspotX : mHotspotX));
+        mPointY = y;
+
+        if (isPositionVisible()) {
+            int[] coords = null;
+
+            if (isShowing()) {
+                coords = mTempCoords;
+                terminalView.getLocationInWindow(coords);
+                int x1 = coords[0] + mPointX;
+                int y1 = coords[1] + mPointY;
+                if (mHandle != null)
+                    mHandle.update(x1, y1, getWidth(), getHeight());
+            } else {
+                show();
+            }
+
+            if (mIsDragging) {
+                if (coords == null) {
+                    coords = mTempCoords;
+                    terminalView.getLocationInWindow(coords);
+                }
+                if (coords[0] != mLastParentX || coords[1] != mLastParentY) {
+                    mTouchToWindowOffsetX += coords[0] - mLastParentX;
+                    mTouchToWindowOffsetY += coords[1] - mLastParentY;
+                    mLastParentX = coords[0];
+                    mLastParentY = coords[1];
+                }
+            }
+        } else {
+            hide();
+        }
+    }
+
+    public void changeOrientation(int orientation) {
+        if (mOrientation != orientation) {
+            setOrientation(orientation);
+        }
+    }
+
+    private void checkChangedOrientation(int posX, boolean force) {
+        if (!mIsDragging && !force) {
+            return;
+        }
+        long millis = SystemClock.currentThreadTimeMillis();
+        if (millis - mLastTime < 50 && !force) {
+            return;
+        }
+        mLastTime = millis;
+
+        final TerminalView hostView = terminalView;
+        final int left = hostView.getLeft();
+        final int right = hostView.getWidth();
+        final int top = hostView.getTop();
+        final int bottom = hostView.getHeight();
+
+        if (mTempRect == null) {
+            mTempRect = new Rect();
+        }
+        final Rect clip = mTempRect;
+        clip.left = left + terminalView.getPaddingLeft();
+        clip.top = top + terminalView.getPaddingTop();
+        clip.right = right - terminalView.getPaddingRight();
+        clip.bottom = bottom - terminalView.getPaddingBottom();
+
+        final ViewParent parent = hostView.getParent();
+        if (parent == null || !parent.getChildVisibleRect(hostView, clip, null)) {
+            return;
+        }
+
+        if (posX - mHandleWidth < clip.left) {
+            changeOrientation(RIGHT);
+        } else if (posX + mHandleWidth > clip.right) {
+            changeOrientation(LEFT);
+        } else {
+            changeOrientation(mInitialOrientation);
+        }
+    }
+
+    private boolean isPositionVisible() {
+        // Always show a dragging handle.
+        if (mIsDragging) {
+            return true;
+        }
+
+        final TerminalView hostView = terminalView;
+        final int left = 0;
+        final int right = hostView.getWidth();
+        final int top = 0;
+        final int bottom = hostView.getHeight();
+
+        if (mTempRect == null) {
+            mTempRect = new Rect();
+        }
+        final Rect clip = mTempRect;
+        clip.left = left + terminalView.getPaddingLeft();
+        clip.top = top + terminalView.getPaddingTop();
+        clip.right = right - terminalView.getPaddingRight();
+        clip.bottom = bottom - terminalView.getPaddingBottom();
+
+        final ViewParent parent = hostView.getParent();
+        if (parent == null || !parent.getChildVisibleRect(hostView, clip, null)) {
+            return false;
+        }
+
+        final int[] coords = mTempCoords;
+        hostView.getLocationInWindow(coords);
+        final int posX = coords[0] + mPointX + (int) mHotspotX;
+        final int posY = coords[1] + mPointY + (int) mHotspotY;
+
+        return posX >= clip.left && posX <= clip.right &&
+            posY >= clip.top && posY <= clip.bottom;
+    }
+
+    @Override
+    public void onDraw(Canvas c) {
+        final int width = mHandleDrawable.getIntrinsicWidth();
+        int height = mHandleDrawable.getIntrinsicHeight();
+        mHandleDrawable.setBounds(0, 0, width, height);
+        mHandleDrawable.draw(c);
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        terminalView.updateFloatingToolbarVisibility(event);
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN: {
+                final float rawX = event.getRawX();
+                final float rawY = event.getRawY();
+                mTouchToWindowOffsetX = rawX - mPointX;
+                mTouchToWindowOffsetY = rawY - mPointY;
+                final int[] coords = mTempCoords;
+                terminalView.getLocationInWindow(coords);
+                mLastParentX = coords[0];
+                mLastParentY = coords[1];
+                mIsDragging = true;
+                break;
+            }
+
+            case MotionEvent.ACTION_MOVE: {
+                final float rawX = event.getRawX();
+                final float rawY = event.getRawY();
+
+                final float newPosX = rawX - mTouchToWindowOffsetX + mHotspotX;
+                final float newPosY = rawY - mTouchToWindowOffsetY + mHotspotY + mTouchOffsetY;
+
+                mCursorController.updatePosition(this, Math.round(newPosX), Math.round(newPosY));
+                break;
+            }
+
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                mIsDragging = false;
+        }
+        return true;
+    }
+
+    @Override
+    public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        setMeasuredDimension(mHandleDrawable.getIntrinsicWidth(),
+            mHandleDrawable.getIntrinsicHeight());
+    }
+
+    public int getHandleHeight() {
+        return mHandleHeight;
+    }
+
+    public int getHandleWidth() {
+        return mHandleWidth;
+    }
+
+    public boolean isShowing() {
+        if (mHandle != null)
+            return mHandle.isShowing();
+        else
+            return false;
+    }
+
+    public boolean isParentNull() {
+        return this.getParent() == null;
+    }
+
+    public boolean isDragging() {
+        return mIsDragging;
+    }
+
+}

--- a/terminal-view/src/main/res/drawable/text_select_handle_left_material.xml
+++ b/terminal-view/src/main/res/drawable/text_select_handle_left_material.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="24dp"
+    android:viewportWidth="132"
+    android:viewportHeight="66">
+  <path
+      android:pathData="M52.3,1.6c-5.7,2.1 -12.9,8.6 -16,14.8 -2.2,4.1 -2.8,6.9 -3.1,14.3 -0.6,12.6 1.3,17.8 9.3,25.8 8,8 13.2,9.9 25.8,9.3 11.1,-0.5 17.3,-3.2 23.5,-10.3 6.5,-7.4 7.2,-10.8 7.2,-34.7l0,-20.8 -21.2,0.1c-16.1,-0 -22.3,0.4 -25.5,1.5z"
+      android:fillColor="#2196F3"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/terminal-view/src/main/res/drawable/text_select_handle_right_material.xml
+++ b/terminal-view/src/main/res/drawable/text_select_handle_right_material.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="24dp"
+    android:viewportWidth="132"
+    android:viewportHeight="66">
+  <path
+      android:pathData="M33,20.8c0,23.9 0.7,27.3 7.2,34.7 6.2,7.1 12.4,9.8 23.5,10.3 12.6,0.6 17.8,-1.3 25.8,-9.3 8,-8 9.9,-13.2 9.3,-25.8 -0.5,-11.1 -3.2,-17.3 -10.3,-23.5 -7.4,-6.5 -10.8,-7.2 -34.7,-7.2l-20.8,-0 0,20.8z"
+      android:fillColor="#2196F3"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/terminal-view/src/main/res/values/strings.xml
+++ b/terminal-view/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+  <string name="paste_text">Paste</string>
+  <string name="copy_text">Copy</string>
+  <string name="text_selection_more">More…</string>
+</resources>


### PR DESCRIPTION
## Summary
- Integrate Termux terminal-emulator and terminal-view as local modules for full interactive shell
- SSH sessions switch from log view to terminal once connected, with keyboard input, cursor, colors, and scrollback
- Extra keys row (ESC, TAB, arrows), PTY resize on layout change, disconnect dialog on back press
- Fix keyboard covering terminal (imePadding) and rotation destroying session (configChanges)
- Plain connection launch no longer auto-loads all port forwards

## Test plan
- [ ] Connect to SSH server — terminal should render correctly
- [ ] Type commands (ls, vim, htop) — interactive programs work
- [ ] Open keyboard — terminal resizes, content stays visible
- [ ] Rotate device — terminal persists
- [ ] Press back — disconnect dialog appears
- [ ] Port forward groups still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)